### PR TITLE
fix: strip empty HTML comments from exported markdown

### DIFF
--- a/src/content/htmlToMarkdown.js
+++ b/src/content/htmlToMarkdown.js
@@ -12,3 +12,18 @@ export default function convertHtmlToMarkdown(htmlContent, showdownConverter) {
 
     return showdownConverter.makeMarkdown(htmlContent);
 }
+
+/**
+ * Removes empty HTML comments from markdown content.
+ * Showdown inserts these after lists to prevent merging during round-trips.
+ *
+ * @param {string} markdown - Markdown content potentially containing empty comments
+ * @returns {string} Markdown with empty HTML comments removed
+ */
+export function stripEmptyHtmlComments(markdown) {
+    if (!markdown) {
+        return '';
+    }
+
+    return markdown.replace(/<!--\s*-->\n?/g, '');
+}

--- a/src/content/htmlToMarkdown.test.js
+++ b/src/content/htmlToMarkdown.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import convertHtmlToMarkdown from './htmlToMarkdown.js';
+import convertHtmlToMarkdown, { stripEmptyHtmlComments } from './htmlToMarkdown.js';
 
 describe('convertHtmlToMarkdown', () => {
     let converter;
@@ -75,5 +75,48 @@ describe('convertHtmlToMarkdown', () => {
         expect(result).toContain('{{LINK:0}}');
         expect(result).toContain('{{LINK:1}}');
         expect(result).toContain('{{ASSET:0}}');
+    });
+});
+
+describe('stripEmptyHtmlComments', () => {
+    it('should strip empty comment with trailing newline', () => {
+        const input = 'before<!-- -->\nafter';
+        expect(stripEmptyHtmlComments(input)).toBe('beforeafter');
+    });
+
+    it('should strip multiple empty comments', () => {
+        const input = '- item 1\n<!-- -->\n- item 2\n<!-- -->\n';
+        expect(stripEmptyHtmlComments(input)).toBe('- item 1\n- item 2\n');
+    });
+
+    it('should preserve non-empty comments', () => {
+        const input = '<!-- keep this -->\nsome text';
+        expect(stripEmptyHtmlComments(input)).toBe('<!-- keep this -->\nsome text');
+    });
+
+    it('should pass through content without comments unchanged', () => {
+        const input = '# Title\n\nSome paragraph text.';
+        expect(stripEmptyHtmlComments(input)).toBe('# Title\n\nSome paragraph text.');
+    });
+
+    it('should strip empty comment at end of file without trailing newline', () => {
+        const input = 'content<!-- -->';
+        expect(stripEmptyHtmlComments(input)).toBe('content');
+    });
+
+    it('should strip empty comments inside code blocks (accepted limitation)', () => {
+        const input = '```\n<!-- -->\n```';
+        expect(stripEmptyHtmlComments(input)).toBe('```\n```');
+    });
+
+    it('should preserve comments with any non-whitespace content', () => {
+        const input = '<!-- TODO -->\n<!-- x -->\n<!--comment-->';
+        expect(stripEmptyHtmlComments(input)).toBe('<!-- TODO -->\n<!-- x -->\n<!--comment-->');
+    });
+
+    it('should return empty string for falsy input', () => {
+        expect(stripEmptyHtmlComments('')).toBe('');
+        expect(stripEmptyHtmlComments(null)).toBe('');
+        expect(stripEmptyHtmlComments(undefined)).toBe('');
     });
 });

--- a/src/pipeline/exportPipeline.js
+++ b/src/pipeline/exportPipeline.js
@@ -3,7 +3,7 @@ import PhaseDefinition from '../domain/PhaseDefinition.js';
 import prepareJournalsForExport from '../journal/prepare.js';
 import { extractLinkReferences, extractAssetReferences } from '../reference/extractFromHTML.js';
 import replaceWithPlaceholders from '../reference/replace.js';
-import convertHtmlToMarkdown from '../content/htmlToMarkdown.js';
+import convertHtmlToMarkdown, { stripEmptyHtmlComments } from '../content/htmlToMarkdown.js';
 import { resolveForExport } from '../reference/resolve.js';
 import identifyAssets from '../asset/identify.js';
 import writeVault from '../vault/write.js';
@@ -116,6 +116,7 @@ export default function createExportPipeline(exportOptions, showdownConverter) {
                         markdownFile.content,
                         ctx.showdownConverter
                     );
+                    markdownFile.content = stripEmptyHtmlComments(markdownFile.content);
                     filesConverted++;
                 }
 


### PR DESCRIPTION
Exported markdown files contain unwanted empty HTML comments (`<!-- -->`) scattered throughout, primarily following bullet lists. These comments degrade readability without serving any purpose.

## Changes
- Add `stripEmptyHtmlComments()` function to `src/content/htmlToMarkdown.js`
- Integrate into `convert-to-markdown` pipeline phase after HTML conversion
- Add 8 test cases covering empty comments, non-empty preservation, and edge cases

## Related Issues
Resolves #4

## Breaking Changes
None