### PR TITLE
fix: use foundry:// protocol for non-journal UUID round-trips

### DIFF
--- a/src/pipeline/exportPipeline.js
+++ b/src/pipeline/exportPipeline.js
@@ -66,7 +66,7 @@ export default function createExportPipeline(exportOptions, showdownConverter) {
             name: 'extract-references',
             execute: async ctx => {
                 for (const markdownFile of ctx.markdownFiles) {
-                    const links = extractLinkReferences(markdownFile.content);
+                    const links = await extractLinkReferences(markdownFile.content);
                     const assets = extractAssetReferences(
                         markdownFile.content,
                         { assetPathPrefix: ctx.exportOptions.assetPathPrefix }

--- a/src/reference/resolve.js
+++ b/src/reference/resolve.js
@@ -166,6 +166,12 @@ function resolveLinks(content, links, linkMap, sourceFilePath) {
     }
 
     for (const link of links) {
+        if (link.metadata?.isFoundryProtocol) {
+            const resolvedLink = `@UUID[${link.foundry}]{${link.label}}`;
+            content = content.replaceAll(link.placeholder, resolvedLink);
+            continue;
+        }
+
         const lowercaseTarget = link.obsidian.toLowerCase();
         const candidates = linkMap.get(lowercaseTarget) || [];
         const targetFile = selectBestMatch(candidates, sourceFilePath);
@@ -273,7 +279,7 @@ function resolveLinksForExport(content, links, linkMap, uuidMap, sourceFilePath)
             }
         } else {
             const displayText = link.label || link.foundry;
-            content = content.replaceAll(link.placeholder, `[[@UUID[${link.foundry}]|${displayText}]]`);
+            content = content.replaceAll(link.placeholder, `[${displayText}](foundry://${link.foundry})`);
         }
     }
 


### PR DESCRIPTION
Fixes non-journal UUID references (Actor, Scene, Item, Compendium) being corrupted during Foundry-Obsidian round-trips. The previous `[[@UUID[...]|label]]` format caused pipe character escaping and regex matching failures.

## Changes
- Export now outputs `[label](foundry://UUID)` for non-journal references
- Import recognizes `[label](foundry://UUID)` and converts to `@UUID[UUID]{label}`
- Made `extractLinkReferences` async to support document name lookup for unlabeled UUIDs
- Added `FOUNDRY_LINK_PATTERN` regex for import extraction
- Updated asset extraction to skip `foundry://` URLs
- Journal references unchanged (still use `[[wiki-link]]` syntax)

## Related Issues
Resolves #5

## Breaking Changes
Existing `[[@UUID[...]|label]]` content in vault files is not automatically converted. Users can re-import affected content if needed.