### PR TITLE
feat: add ZIP fallback for browsers without File System Access API

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,6 +14,9 @@
     "minimum": "12",
     "verified": "14"
   },
+  "scripts": [
+    "dist/lib/jszip.min.js"
+  ],
   "esmodules": [
     "dist/obsidian-bridge.js"
   ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -85,6 +85,10 @@ const main = {
                         }
                     },
                     rename: (name) => `${name}.json`
+                },
+                {
+                    src: './node_modules/jszip/dist/jszip.min.js',
+                    dest: './dist/lib'
                 }
             ],
             hookTimeout: 30000

--- a/src/lang/en.yaml
+++ b/src/lang/en.yaml
@@ -51,6 +51,7 @@ obsidian-bridge:
     asset-path-prefix-hint: Path prefix to remove from Foundry asset URLs
 
     export-button: Export
+    download-zip-button: Download ZIP
     cancel-button: Cancel
 
     no-directory-selected: Please select a directory for export

--- a/src/ui/ExportDialog.js
+++ b/src/ui/ExportDialog.js
@@ -19,6 +19,7 @@ export default class ExportDialog extends HandlebarsApplicationMixin(Application
         this.assetPathPrefix = `worlds/${game.world.id}/obsidian-assets`;
         this.exportPath = '';
         this.directoryHandle = null;
+        this.hasFilesystemAccess = typeof window.showDirectoryPicker === 'function';
     }
 
     static DEFAULT_OPTIONS = {
@@ -59,7 +60,8 @@ export default class ExportDialog extends HandlebarsApplicationMixin(Application
             merge: this.merge,
             exportAssets: this.exportAssets,
             assetPathPrefix: this.assetPathPrefix,
-            exportPath: this.exportPath
+            exportPath: this.exportPath,
+            hasFilesystemAccess: this.hasFilesystemAccess
         };
     }
 
@@ -202,7 +204,7 @@ export default class ExportDialog extends HandlebarsApplicationMixin(Application
         this.exportAssets = data.exportAssets || false;
         this.assetPathPrefix = data.assetPathPrefix || '';
 
-        if (!this.directoryHandle) {
+        if (this.hasFilesystemAccess && !this.directoryHandle) {
             ui.notifications.warn(game.i18n.localize('obsidian-bridge.export.no-directory-selected'));
             return;
         }

--- a/src/vault/write.test.js
+++ b/src/vault/write.test.js
@@ -84,7 +84,7 @@ beforeEach(() => {
             this.type = 'application/octet-stream';
         }
     };
-    global.JSZip = mockJSZip;
+    globalThis.JSZip = mockJSZip;
 });
 
 describe('writeVault', () => {

--- a/templates/export-dialog.hbs
+++ b/templates/export-dialog.hbs
@@ -1,4 +1,5 @@
 <div class="export-dialog-content">
+    {{#if hasFilesystemAccess}}
     <div class="form-group">
         <label for="obsidian-export-path">{{localize "obsidian-bridge.export.export-path-label"}}</label>
         <div class="form-fields">
@@ -10,6 +11,7 @@
         </div>
         <p class="hint">{{localize "obsidian-bridge.export.export-path-hint"}}</p>
     </div>
+    {{/if}}
 
     {{#if journalTree}}
     <div class="form-group file-tree-group">
@@ -48,7 +50,11 @@
 
     <footer class="form-footer flexrow">
         <button type="submit" class="primary">
+            {{#if hasFilesystemAccess}}
             <i class="fas fa-file-export"></i> {{localize "obsidian-bridge.export.export-button"}}
+            {{else}}
+            <i class="fas fa-download"></i> {{localize "obsidian-bridge.export.download-zip-button"}}
+            {{/if}}
         </button>
         <button type="button" data-action="close">
             <i class="fas fa-times"></i> {{localize "obsidian-bridge.export.cancel-button"}}


### PR DESCRIPTION
Adds ZIP download fallback for browsers that don't support the File System Access API (Firefox, Safari, and remote browser connections).

## Changes
- Detect `showDirectoryPicker` availability in ExportDialog constructor
- Hide folder picker UI when API is unavailable
- Show "Download ZIP" button with download icon instead of "Export"
- Skip directory validation when using ZIP fallback
- Bundle JSZip as a script dependency for runtime use

## Related Issues
Resolves #1

## Breaking Changes
None