### PR TITLE
feat: detect sync conflicts before overwriting Foundry edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-/.claude
 /coverage
 /dist
 /node_modules
-/CLAUDE.md
 .env
 .idea/
 *.iml

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -662,6 +663,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -685,6 +687,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3352,6 +3355,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3837,6 +3841,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4724,6 +4729,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9924,6 +9930,7 @@
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/src/conflict/detectConflicts.js
+++ b/src/conflict/detectConflicts.js
@@ -1,0 +1,150 @@
+/**
+ * Detect pages that have been modified in Foundry since last sync.
+ *
+ * A conflict occurs when:
+ * 1. A page already exists in Foundry matching the import target
+ * 2. The page has a lastSyncedAt timestamp (not a first-time import)
+ * 3. The page's modifiedTime > lastSyncedAt (edited since last sync)
+ *
+ * Dependencies: Foundry (game.folders, game.journal APIs)
+ */
+
+/**
+ * Detects conflicts between the import plan and existing Foundry documents.
+ *
+ * @param {import('../domain/JournalStructurePlan').default} structurePlan - The planned journal structure
+ * @returns {Promise<Conflict[]>} Array of detected conflicts
+ */
+export async function detectConflicts(structurePlan) {
+    const folderIndex = buildFolderIndex();
+    const entryIndex = buildEntryIndex();
+    const conflicts = [];
+
+    for (const entryPlan of structurePlan.entries) {
+        const folderId = resolveFolderId(entryPlan.folderPath, folderIndex);
+        const entryKey = `${folderId}:${entryPlan.name}`;
+        const existingEntry = entryIndex.get(entryKey);
+
+        if (!existingEntry) {
+            continue;
+        }
+
+        const pageIndex = new Map();
+        for (const page of existingEntry.pages) {
+            pageIndex.set(page.name, page);
+        }
+
+        for (const pagePlan of entryPlan.pages) {
+            const existingPage = pageIndex.get(pagePlan.name);
+
+            if (!existingPage) {
+                continue;
+            }
+
+            const conflict = checkPageConflict(existingPage, existingEntry, pagePlan);
+            if (conflict) {
+                conflicts.push(conflict);
+            }
+        }
+    }
+
+    return conflicts;
+}
+
+function buildFolderIndex() {
+    const index = new Map();
+
+    for (const folder of game.folders.filter(f => f.type === 'JournalEntry')) {
+        const key = `${folder.folder?.id ?? null}:${folder.name}`;
+        index.set(key, folder);
+    }
+
+    return index;
+}
+
+function buildEntryIndex() {
+    const index = new Map();
+
+    for (const entry of game.journal) {
+        const key = `${entry.folder?.id ?? null}:${entry.name}`;
+        index.set(key, entry);
+    }
+
+    return index;
+}
+
+/**
+ * Resolves a folder path to a Foundry folder ID.
+ *
+ * @param {string|null} folderPath - The folder path from the plan
+ * @param {Map} folderIndex - Index of existing folders
+ * @returns {string|null} The folder ID or null
+ */
+function resolveFolderId(folderPath, folderIndex) {
+    if (!folderPath) {
+        return null;
+    }
+
+    let parentId = null;
+    for (const name of folderPath.split('/')) {
+        const folder = folderIndex.get(`${parentId}:${name}`);
+        if (!folder) {
+            return null;
+        }
+        parentId = folder.id;
+    }
+
+    return parentId;
+}
+
+// Tolerance for timing differences between Date.now() and Foundry's modifiedTime.
+// When we update a page, we call Date.now() before Foundry processes the update,
+// so modifiedTime ends up slightly newer than lastSyncedAt. A 5-second window
+// handles this while still catching real user edits.
+const SYNC_TOLERANCE_MS = 5000;
+
+/**
+ * Checks if a page has been modified since last sync.
+ *
+ * @param {JournalEntryPage} page - The existing Foundry page
+ * @param {JournalEntry} entry - The parent journal entry
+ * @param {Object} pagePlan - The page plan from structure
+ * @returns {Conflict|null} Conflict info or null if no conflict
+ */
+function checkPageConflict(page, entry, pagePlan) {
+    const lastSyncedAt = page.flags?.['obsidian-bridge']?.lastSyncedAt;
+    if (lastSyncedAt == null) {
+        return null;
+    }
+
+    const modifiedTime = page._stats?.modifiedTime;
+
+    if (!modifiedTime || modifiedTime <= lastSyncedAt + SYNC_TOLERANCE_MS) {
+        return null;
+    }
+
+    return {
+        pageUuid: page.uuid,
+        pageName: page.name,
+        entryName: entry.name,
+        modifiedTime,
+        lastSyncedAt,
+        markdownFile: pagePlan.markdownFile
+    };
+}
+
+/**
+ * Filters out markdown files that the user chose to skip.
+ *
+ * @param {MarkdownFile[]} markdownFiles - Array of markdown files (mutated)
+ * @param {Conflict[]} skippedConflicts - Conflicts the user chose not to overwrite
+ */
+export function filterSkippedFiles(markdownFiles, skippedConflicts) {
+    const skippedFiles = new Set(skippedConflicts.map(c => c.markdownFile));
+
+    for (let i = markdownFiles.length - 1; i >= 0; i--) {
+        if (skippedFiles.has(markdownFiles[i])) {
+            markdownFiles.splice(i, 1);
+        }
+    }
+}

--- a/src/journal/update.js
+++ b/src/journal/update.js
@@ -25,16 +25,19 @@ export async function updateContent(markdownFiles) {
 
         const originalContent = page.text?.content || '';
         const originalFrontmatter = page.flags?.['obsidian-bridge']?.frontmatter ?? null;
+        const originalLastSyncedAt = page.flags?.['obsidian-bridge']?.lastSyncedAt ?? null;
 
         await page.update({
             'text.content': markdownFile.content,
-            'flags.obsidian-bridge.frontmatter': markdownFile.frontmatter
+            'flags.obsidian-bridge.frontmatter': markdownFile.frontmatter,
+            'flags.obsidian-bridge.lastSyncedAt': Date.now()
         });
 
         updatedPages.push({
             page,
             originalContent,
-            originalFrontmatter
+            originalFrontmatter,
+            originalLastSyncedAt
         });
     }
 
@@ -48,11 +51,12 @@ export async function rollbackUpdates(updatedPages) {
 
     const reversedPages = [...updatedPages].reverse();
 
-    for (const { page, originalContent, originalFrontmatter } of reversedPages) {
+    for (const { page, originalContent, originalFrontmatter, originalLastSyncedAt } of reversedPages) {
         try {
             await page.update({
                 'text.content': originalContent,
-                'flags.obsidian-bridge.frontmatter': originalFrontmatter
+                'flags.obsidian-bridge.frontmatter': originalFrontmatter,
+                'flags.obsidian-bridge.lastSyncedAt': originalLastSyncedAt
             });
         } catch (error) {
             console.error(`Failed to rollback page ${page.uuid}:`, error);

--- a/src/journal/update.test.js
+++ b/src/journal/update.test.js
@@ -38,7 +38,8 @@ describe('journal/update', () => {
             expect(mockFromUuidSync).toHaveBeenCalledWith(mockPage.uuid);
             expect(mockPage.update).toHaveBeenCalledWith({
                 'text.content': '<p>New content</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': expect.any(Number)
             });
 
             expect(result.updatedPages).toHaveLength(1);
@@ -79,11 +80,13 @@ describe('journal/update', () => {
 
             expect(mockPage1.update).toHaveBeenCalledWith({
                 'text.content': '<p>New 1</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': expect.any(Number)
             });
             expect(mockPage2.update).toHaveBeenCalledWith({
                 'text.content': '<p>New 2</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': expect.any(Number)
             });
 
             expect(result.updatedPages).toHaveLength(2);
@@ -224,7 +227,8 @@ describe('journal/update', () => {
 
             expect(mockPage.update).toHaveBeenCalledWith({
                 'text.content': '<p>New content</p>',
-                'flags.obsidian-bridge.frontmatter': 'title: Hello'
+                'flags.obsidian-bridge.frontmatter': 'title: Hello',
+                'flags.obsidian-bridge.lastSyncedAt': expect.any(Number)
             });
         });
 
@@ -249,7 +253,8 @@ describe('journal/update', () => {
 
             expect(mockPage.update).toHaveBeenCalledWith({
                 'text.content': '<p>New content</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': expect.any(Number)
             });
         });
 
@@ -318,19 +323,21 @@ describe('journal/update', () => {
             };
 
             const updatedPages = [
-                { page: mockPage1, originalContent: '<p>Original 1</p>', originalFrontmatter: null },
-                { page: mockPage2, originalContent: '<p>Original 2</p>', originalFrontmatter: null }
+                { page: mockPage1, originalContent: '<p>Original 1</p>', originalFrontmatter: null, originalLastSyncedAt: 1000 },
+                { page: mockPage2, originalContent: '<p>Original 2</p>', originalFrontmatter: null, originalLastSyncedAt: 2000 }
             ];
 
             await rollbackUpdates(updatedPages);
 
             expect(mockPage2.update).toHaveBeenCalledWith({
                 'text.content': '<p>Original 2</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': 2000
             });
             expect(mockPage1.update).toHaveBeenCalledWith({
                 'text.content': '<p>Original 1</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': 1000
             });
             expect(updateOrder).toEqual(['page2', 'page1']);
         });
@@ -347,8 +354,8 @@ describe('journal/update', () => {
             };
 
             const updatedPages = [
-                { page: mockPage1, originalContent: '<p>Original 1</p>', originalFrontmatter: null },
-                { page: mockPage2, originalContent: '<p>Original 2</p>', originalFrontmatter: null }
+                { page: mockPage1, originalContent: '<p>Original 1</p>', originalFrontmatter: null, originalLastSyncedAt: null },
+                { page: mockPage2, originalContent: '<p>Original 2</p>', originalFrontmatter: null, originalLastSyncedAt: null }
             ];
 
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
@@ -381,7 +388,7 @@ describe('journal/update', () => {
             };
 
             const updatedPages = [
-                { page: mockPage, originalContent: '<p>Original</p>', originalFrontmatter: null }
+                { page: mockPage, originalContent: '<p>Original</p>', originalFrontmatter: null, originalLastSyncedAt: null }
             ];
 
             const originalLength = updatedPages.length;
@@ -402,7 +409,8 @@ describe('journal/update', () => {
                 {
                     page: mockPage,
                     originalContent: '<p>Original</p>',
-                    originalFrontmatter: 'title: Original'
+                    originalFrontmatter: 'title: Original',
+                    originalLastSyncedAt: 12345
                 }
             ];
 
@@ -410,7 +418,8 @@ describe('journal/update', () => {
 
             expect(mockPage.update).toHaveBeenCalledWith({
                 'text.content': '<p>Original</p>',
-                'flags.obsidian-bridge.frontmatter': 'title: Original'
+                'flags.obsidian-bridge.frontmatter': 'title: Original',
+                'flags.obsidian-bridge.lastSyncedAt': 12345
             });
         });
 
@@ -424,7 +433,8 @@ describe('journal/update', () => {
                 {
                     page: mockPage,
                     originalContent: '<p>Original</p>',
-                    originalFrontmatter: null
+                    originalFrontmatter: null,
+                    originalLastSyncedAt: null
                 }
             ];
 
@@ -432,7 +442,8 @@ describe('journal/update', () => {
 
             expect(mockPage.update).toHaveBeenCalledWith({
                 'text.content': '<p>Original</p>',
-                'flags.obsidian-bridge.frontmatter': null
+                'flags.obsidian-bridge.frontmatter': null,
+                'flags.obsidian-bridge.lastSyncedAt': null
             });
         });
     });

--- a/src/lang/en.yaml
+++ b/src/lang/en.yaml
@@ -57,6 +57,16 @@ obsidian-bridge:
     no-directory-selected: Please select a directory for export
     no-journals-selected: Please select at least one journal to export
 
+  conflicts:
+    dialog-title: Sync Conflicts Detected
+    warning-message: "{count} page(s) have been modified in Foundry since the last sync."
+    instructions: "Checked pages will be overwritten with content from Obsidian. Uncheck pages you want to keep."
+    column-page: Page
+    column-journal: Journal
+    column-modified: Last Modified
+    continue-button: Continue Import
+    abort-button: Abort
+
   progress:
     title: Processing...
     starting: Starting...
@@ -69,10 +79,12 @@ obsidian-bridge:
     replace-references: Replacing references
     convert-markdown: Converting markdown to HTML
     plan-structure: Planning journal structure
+    detect-conflicts: Checking for conflicts
     create-documents: Creating journal documents
     upload-assets: Uploading assets
     resolve-placeholders: Resolving references
     update-content: Updating content
+    update-sync-timestamps: Updating sync timestamps
 
     collect-journals: Collecting journals
     convert-to-markdown: Converting HTML to markdown

--- a/src/pipeline/exportPipeline.js
+++ b/src/pipeline/exportPipeline.js
@@ -23,6 +23,7 @@ import { extractCalloutsToPlaceholders, restoreCalloutPlaceholders } from '../ca
  * 7. prepend-frontmatter - Prepend stored frontmatter to markdown content
  * 8. identify-assets - Identify asset paths to export (conditional on exportAssets)
  * 9. write-vault - Write files to filesystem or ZIP
+ * 10. update-sync-timestamps - Update lastSyncedAt flag on exported pages
  *
  * @param {import('../domain/ExportOptions.js').default} exportOptions - Export configuration
  * @param {import('showdown').Converter} showdownConverter - Showdown converter instance
@@ -186,6 +187,39 @@ export default function createExportPipeline(exportOptions, showdownConverter) {
                 }
 
                 return result;
+            }
+        }),
+
+        new PhaseDefinition({
+            name: 'update-sync-timestamps',
+            execute: async ctx => {
+                const timestamp = Date.now();
+                let pagesUpdated = 0;
+
+                for (const markdownFile of ctx.markdownFiles) {
+                    const uuid = markdownFile.foundryPageUuid;
+                    if (!uuid) {
+                        continue;
+                    }
+
+                    const doc = fromUuidSync(uuid);
+                    if (!doc) {
+                        console.warn(`Could not find document for UUID: ${uuid}`);
+                        continue;
+                    }
+
+                    if (doc.documentName === 'JournalEntryPage') {
+                        await doc.update({ 'flags.obsidian-bridge.lastSyncedAt': timestamp });
+                        pagesUpdated++;
+                    } else if (doc.documentName === 'JournalEntry') {
+                        for (const page of doc.pages) {
+                            await page.update({ 'flags.obsidian-bridge.lastSyncedAt': timestamp });
+                            pagesUpdated++;
+                        }
+                    }
+                }
+
+                return { pagesUpdated };
             }
         })
     ];

--- a/src/pipeline/importPipeline.js
+++ b/src/pipeline/importPipeline.js
@@ -14,6 +14,8 @@ import { extractFrontmatter } from '../content/frontmatter.js';
 import convertNewlinesToBr from '../content/markdownPreprocess.js';
 import { extractCallouts } from '../callout/extract.js';
 import { replaceCalloutPlaceholders } from '../callout/replace.js';
+import { detectConflicts, filterSkippedFiles } from '../conflict/detectConflicts.js';
+import ConflictDialog from '../ui/ConflictDialog.js';
 
 /**
  * Creates a configured pipeline for importing an Obsidian vault into Foundry.
@@ -29,10 +31,11 @@ import { replaceCalloutPlaceholders } from '../callout/replace.js';
  * 8. Replace references - Replace references with placeholders
  * 9. Convert markdown - Convert markdown text to HTML
  * 10. Plan structure - Determine folder and journal entry structure
- * 11. Create documents - Create Foundry folders, journal entries, and pages
- * 12. Upload assets - Upload non-markdown files to data path (conditional)
- * 13. Resolve placeholders - Replace placeholders with actual UUIDs and paths
- * 14. Update content - Write final HTML content to journal pages
+ * 11. Detect conflicts - Check for pages modified since last sync, prompt user
+ * 12. Create documents - Create Foundry folders, journal entries, and pages
+ * 13. Upload assets - Upload non-markdown files to data path (conditional)
+ * 14. Resolve placeholders - Replace placeholders with actual UUIDs and paths
+ * 15. Update content - Write final HTML content to journal pages
  *
  * @param {import('../domain/ImportOptions').default} importOptions - Import configuration
  * @param {import('showdown').Converter} showdownConverter - Markdown to HTML converter
@@ -192,6 +195,22 @@ export default function createImportPipeline(importOptions, showdownConverter) {
                 const structurePlan = planJournalStructure(ctx.markdownFiles, ctx.importOptions);
                 ctx.structurePlan = structurePlan;
                 return { structurePlan };
+            },
+        }),
+
+        new PhaseDefinition({
+            name: 'detect-conflicts',
+            execute: async ctx => {
+                const conflicts = await detectConflicts(ctx.structurePlan);
+
+                if (conflicts.length === 0) {
+                    return { conflicts: [], skipped: [] };
+                }
+
+                const skipped = await ConflictDialog.prompt(conflicts);
+                filterSkippedFiles(ctx.markdownFiles, skipped);
+
+                return { conflicts, skipped };
             },
         }),
 

--- a/src/style/_conflict.scss
+++ b/src/style/_conflict.scss
@@ -1,0 +1,62 @@
+.obsidian-bridge {
+    &.conflict-dialog {
+        .conflict-warning {
+            color: var(--color-level-warning);
+            font-weight: bold;
+            margin-bottom: 0.5rem;
+
+            i {
+                margin-right: 0.5rem;
+            }
+        }
+
+        .conflict-instructions {
+            margin-bottom: 1rem;
+            color: var(--color-text-dark-secondary);
+        }
+
+        .conflict-list {
+            border: 1px solid var(--color-border-dark);
+            max-height: 300px;
+            overflow-y: auto;
+            margin-bottom: 1rem;
+
+            table {
+                width: 100%;
+                border-collapse: collapse;
+
+                th, td {
+                    padding: 0.5rem;
+                    text-align: left;
+                    border-bottom: 1px solid var(--color-border-light-tertiary);
+                }
+
+                th {
+                    background: var(--color-cool-5);
+                    font-weight: bold;
+                    position: sticky;
+                    top: 0;
+                }
+
+                .col-checkbox {
+                    width: 2rem;
+                    text-align: center;
+                }
+
+                .col-page {
+                    width: 35%;
+                }
+
+                .col-journal {
+                    width: 30%;
+                }
+
+                .col-modified {
+                    width: 35%;
+                    font-size: 0.9em;
+                    color: var(--color-text-dark-secondary);
+                }
+            }
+        }
+    }
+}

--- a/src/style/obsidian-bridge.scss
+++ b/src/style/obsidian-bridge.scss
@@ -4,6 +4,7 @@
 @use "export";
 @use "progress";
 @use "callout";
+@use "conflict";
 
 .directory .directory-footer .action-buttons {
     gap: 8px;

--- a/src/ui/ConflictDialog.js
+++ b/src/ui/ConflictDialog.js
@@ -1,0 +1,126 @@
+/**
+ * Dialog for resolving sync conflicts during import.
+ *
+ * Shows pages that have been modified in Foundry since last sync.
+ * Users can check pages to overwrite or uncheck to skip.
+ *
+ * Dependencies: Foundry (ApplicationV2, HandlebarsApplicationMixin)
+ */
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+export default class ConflictDialog extends HandlebarsApplicationMixin(ApplicationV2) {
+    #resolve = null;
+    #reject = null;
+
+    constructor(conflicts, options = {}) {
+        super(options);
+        this.conflicts = conflicts.map(c => ({
+            ...c,
+            checked: true,
+            formattedModifiedTime: this._formatTimestamp(c.modifiedTime),
+            formattedLastSyncedAt: this._formatTimestamp(c.lastSyncedAt)
+        }));
+    }
+
+    static DEFAULT_OPTIONS = {
+        id: 'obsidian-bridge-conflicts',
+        classes: ['obsidian-bridge', 'conflict-dialog'],
+        tag: 'form',
+        window: {
+            frame: true,
+            positioned: true,
+            title: 'obsidian-bridge.conflicts.dialog-title',
+            icon: 'fas fa-exclamation-triangle',
+            minimizable: false,
+            resizable: false
+        },
+        actions: {
+            continue: ConflictDialog._onContinue,
+            abort: ConflictDialog._onAbort
+        },
+        position: {
+            width: 550,
+            height: 'auto'
+        }
+    };
+
+    static PARTS = {
+        form: {
+            template: 'modules/obsidian-bridge/templates/conflict-dialog.hbs'
+        }
+    };
+
+    async _prepareContext(options) {
+        return {
+            conflicts: this.conflicts,
+            conflictCount: this.conflicts.length
+        };
+    }
+
+    _onRender(context, options) {
+        super._onRender(context, options);
+
+        const checkboxes = this.element.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach(checkbox => {
+            checkbox.addEventListener('change', () => {
+                const conflict = this.conflicts.find(c => c.pageUuid === checkbox.dataset.uuid);
+                if (conflict) {
+                    conflict.checked = checkbox.checked;
+                }
+            });
+        });
+    }
+
+    _formatTimestamp(timestamp) {
+        if (!timestamp) {
+            return 'Unknown';
+        }
+        const date = new Date(timestamp);
+        return date.toLocaleString();
+    }
+
+    /**
+     * Opens the dialog and returns a promise that resolves with skipped conflicts.
+     *
+     * @param {Conflict[]} conflicts - Array of conflicts to display
+     * @returns {Promise<Conflict[]>} Conflicts the user chose to skip (unchecked)
+     * @throws {Error} If user clicks Abort
+     */
+    static async prompt(conflicts) {
+        const dialog = new ConflictDialog(conflicts);
+
+        return new Promise((resolve, reject) => {
+            dialog.#resolve = resolve;
+            dialog.#reject = reject;
+            dialog.render(true);
+        });
+    }
+
+    static _onContinue(event, target) {
+        event.preventDefault();
+
+        const skipped = this.conflicts.filter(c => !c.checked);
+        this.#resolve(skipped);
+        this.#resolve = null;
+        this.#reject = null;
+        this.close();
+    }
+
+    static _onAbort(event, target) {
+        event.preventDefault();
+
+        this.#reject(new Error('Import aborted by user'));
+        this.#resolve = null;
+        this.#reject = null;
+        this.close();
+    }
+
+    async close(options = {}) {
+        if (this.#reject) {
+            this.#reject(new Error('Dialog closed'));
+            this.#reject = null;
+        }
+        return super.close(options);
+    }
+}

--- a/templates/conflict-dialog.hbs
+++ b/templates/conflict-dialog.hbs
@@ -1,0 +1,44 @@
+<div class="conflict-dialog-content">
+    <p class="conflict-warning">
+        <i class="fas fa-exclamation-triangle"></i>
+        {{localize "obsidian-bridge.conflicts.warning-message" count=conflictCount}}
+    </p>
+
+    <p class="conflict-instructions">
+        {{localize "obsidian-bridge.conflicts.instructions"}}
+    </p>
+
+    <div class="conflict-list">
+        <table>
+            <thead>
+                <tr>
+                    <th class="col-checkbox"></th>
+                    <th class="col-page">{{localize "obsidian-bridge.conflicts.column-page"}}</th>
+                    <th class="col-journal">{{localize "obsidian-bridge.conflicts.column-journal"}}</th>
+                    <th class="col-modified">{{localize "obsidian-bridge.conflicts.column-modified"}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#each conflicts}}
+                <tr>
+                    <td class="col-checkbox">
+                        <input type="checkbox" data-uuid="{{pageUuid}}" {{checked checked}} />
+                    </td>
+                    <td class="col-page">{{pageName}}</td>
+                    <td class="col-journal">{{entryName}}</td>
+                    <td class="col-modified">{{formattedModifiedTime}}</td>
+                </tr>
+                {{/each}}
+            </tbody>
+        </table>
+    </div>
+
+    <footer class="form-footer flexrow">
+        <button type="button" data-action="continue" class="primary">
+            <i class="fas fa-check"></i> {{localize "obsidian-bridge.conflicts.continue-button"}}
+        </button>
+        <button type="button" data-action="abort">
+            <i class="fas fa-times"></i> {{localize "obsidian-bridge.conflicts.abort-button"}}
+        </button>
+    </footer>
+</div>


### PR DESCRIPTION
Adds conflict detection to the import pipeline. When a page has been modified in Foundry since the last sync, users are prompted before overwriting.

## Changes
- Store `lastSyncedAt` timestamp on pages during import and export
- Add `detect-conflicts` phase to import pipeline after `plan-structure`
- Add `update-sync-timestamps` phase to export pipeline after `write-vault`
- New `ConflictDialog` UI showing affected pages with checkboxes
- 5-second tolerance window to handle timing differences

## Related Issues
Resolves #15

## Breaking Changes
None