### PR TITLE
feat: import Fantasy Statblocks as dnd5e NPC actors

### DIFF
--- a/src/domain/ImportOptions.js
+++ b/src/domain/ImportOptions.js
@@ -13,7 +13,9 @@ export default class ImportOptions {
         splitHeadingLevel: 1,
         importAssets: false,
         strictLineBreaks: false,
-        dataPath: ''
+        dataPath: '',
+        importStatblocks: false,
+        statblockFolder: null
     };
 
     constructor(options = {}) {

--- a/src/domain/StatblockData.js
+++ b/src/domain/StatblockData.js
@@ -1,66 +1,43 @@
 /**
  * Intermediate representation for creature statblocks.
  * Matches the Fantasy Statblocks format used in Obsidian.
- * Object is sealed after construction to prevent accidental property additions.
- *
- * Properties mutated during import:
- * - _action: Set during conflict resolution ('create', 'update', 'skip')
- * - _existingActor: Set when an existing actor is found for update
  */
 export default class StatblockData {
     static DEFAULTS = {
-        // Identity
         name: '',
         filePath: '',
-
-        // Core stats
-        size: '',           // tiny, sm, med, lg, huge, grg
-        type: '',           // creature type
+        size: '',
+        type: '',
         subtype: '',
         alignment: '',
-
-        // Combat
-        ac: null,           // number or {value, type}
-        hp: null,           // number
-        hitDice: '',        // e.g., "12d10+60"
-        speed: null,        // {walk: 30, fly: 60, ...}
-
-        // Abilities
-        abilities: null,    // {str: 10, dex: 10, ...} - defaults applied in constructor
-        savingThrows: null, // {str: 5, dex: 3, ...}
-        skills: null,       // {perception: 5, stealth: 3, ...}
-
-        // Traits
+        ac: null,
+        hp: null,
+        hitDice: '',
+        speed: null,
+        abilities: null,
+        savingThrows: null,
+        skills: null,
         damageVulnerabilities: null,
         damageResistances: null,
         damageImmunities: null,
         conditionImmunities: null,
-        senses: null,       // {darkvision: 60, passivePerception: 15}
+        senses: null,
         languages: null,
-
-        // Challenge
-        cr: null,           // number or fraction string
-
-        // Features and Actions
-        traits: null,       // [{name, desc}, ...]
+        cr: null,
+        traits: null,
         actions: null,
         bonusActions: null,
         reactions: null,
         legendaryActions: null,
         legendaryDescription: '',
-
-        // Spellcasting (Fantasy Statblocks spells array)
-        spells: null,       // Array of spell list strings
-
-        // Internal (set during import)
-        _action: null,      // 'create', 'update', 'skip'
+        spells: null,
+        _action: null,
         _existingActor: null
     };
 
     constructor(options = {}) {
         Object.assign(this, StatblockData.DEFAULTS, options);
 
-        // Apply mutable defaults for fields that weren't provided
         this.speed = this.speed ?? {};
         this.abilities = this.abilities ?? { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 };
         this.savingThrows = this.savingThrows ?? {};

--- a/src/domain/StatblockData.js
+++ b/src/domain/StatblockData.js
@@ -1,0 +1,83 @@
+/**
+ * Intermediate representation for creature statblocks.
+ * Matches the Fantasy Statblocks format used in Obsidian.
+ * Object is sealed after construction to prevent accidental property additions.
+ *
+ * Properties mutated during import:
+ * - _action: Set during conflict resolution ('create', 'update', 'skip')
+ * - _existingActor: Set when an existing actor is found for update
+ */
+export default class StatblockData {
+    static DEFAULTS = {
+        // Identity
+        name: '',
+        filePath: '',
+
+        // Core stats
+        size: '',           // tiny, sm, med, lg, huge, grg
+        type: '',           // creature type
+        subtype: '',
+        alignment: '',
+
+        // Combat
+        ac: null,           // number or {value, type}
+        hp: null,           // number
+        hitDice: '',        // e.g., "12d10+60"
+        speed: null,        // {walk: 30, fly: 60, ...}
+
+        // Abilities
+        abilities: null,    // {str: 10, dex: 10, ...} - defaults applied in constructor
+        savingThrows: null, // {str: 5, dex: 3, ...}
+        skills: null,       // {perception: 5, stealth: 3, ...}
+
+        // Traits
+        damageVulnerabilities: null,
+        damageResistances: null,
+        damageImmunities: null,
+        conditionImmunities: null,
+        senses: null,       // {darkvision: 60, passivePerception: 15}
+        languages: null,
+
+        // Challenge
+        cr: null,           // number or fraction string
+
+        // Features and Actions
+        traits: null,       // [{name, desc}, ...]
+        actions: null,
+        bonusActions: null,
+        reactions: null,
+        legendaryActions: null,
+        legendaryDescription: '',
+
+        // Spellcasting (Fantasy Statblocks spells array)
+        spells: null,       // Array of spell list strings
+
+        // Internal (set during import)
+        _action: null,      // 'create', 'update', 'skip'
+        _existingActor: null
+    };
+
+    constructor(options = {}) {
+        Object.assign(this, StatblockData.DEFAULTS, options);
+
+        // Apply mutable defaults for fields that weren't provided
+        this.speed = this.speed ?? {};
+        this.abilities = this.abilities ?? { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 };
+        this.savingThrows = this.savingThrows ?? {};
+        this.skills = this.skills ?? {};
+        this.damageVulnerabilities = this.damageVulnerabilities ?? [];
+        this.damageResistances = this.damageResistances ?? [];
+        this.damageImmunities = this.damageImmunities ?? [];
+        this.conditionImmunities = this.conditionImmunities ?? [];
+        this.senses = this.senses ?? {};
+        this.languages = this.languages ?? [];
+        this.traits = this.traits ?? [];
+        this.actions = this.actions ?? [];
+        this.bonusActions = this.bonusActions ?? [];
+        this.reactions = this.reactions ?? [];
+        this.legendaryActions = this.legendaryActions ?? [];
+        this.spells = this.spells ?? [];
+
+        Object.seal(this);
+    }
+}

--- a/src/lang/en.yaml
+++ b/src/lang/en.yaml
@@ -33,6 +33,11 @@ obsidian-bridge:
     data-path-label: Data path for non-markdown files
     data-path-hint: Directory where imported assets will be stored
 
+    statblock-label: Import Statblocks as Actors
+    statblock-hint: Create NPC actors from Fantasy Statblock code blocks
+    statblock-folder-label: Actor Folder
+    statblock-folder-none: "— Root —"
+
     import-button: Import
     cancel-button: Cancel
 
@@ -80,7 +85,13 @@ obsidian-bridge:
 
     filter-files: Filtering selected files
     prepare-documents: Preparing documents
+    prepare-statblocks: Parsing statblocks
+    detect-statblock-conflicts: Checking for existing actors
+    import-statblock-actors: Creating actors from statblocks
+    extract-frontmatter: Extracting frontmatter
+    extract-callouts: Extracting callouts
     convert-line-breaks: Converting line breaks
+    replace-callouts: Processing callouts
     extract-references: Extracting references
     replace-references: Replacing references
     convert-markdown: Converting markdown to HTML

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 import { registerImportHooks } from './infrastructure/registerHooks.js';
+import { registerDnd5eAdapter } from './statblock/adapters/dnd5e/index.js';
 
 Hooks.once('init', async () => {
     console.log('Obsidian Bridge | Initializing');
+    registerDnd5eAdapter();
     await registerImportHooks();
 });

--- a/src/pipeline/importPipeline.js
+++ b/src/pipeline/importPipeline.js
@@ -16,6 +16,96 @@ import { extractCallouts } from '../callout/extract.js';
 import { replaceCalloutPlaceholders } from '../callout/replace.js';
 import { detectConflicts, filterSkippedFiles } from '../conflict/detectConflicts.js';
 import ConflictDialog from '../ui/ConflictDialog.js';
+import { extractStatblocks } from '../statblock/extract.js';
+import { parseStatblock } from '../statblock/parse.js';
+import StatblockAdapterRegistry from '../statblock/registry.js';
+import { id as MODULE_ID } from '../../module.json';
+
+/**
+ * Gets the parent folder path from a file path.
+ * @param {string} filePath - Full file path like "Bestiary/Bugbears/Bugbear Brute.md"
+ * @returns {string|null} Parent path like "Bestiary/Bugbears" or null if at root
+ */
+function getParentPath(filePath) {
+    if (!filePath) {
+        return null;
+    }
+    const lastSlash = filePath.lastIndexOf('/');
+    if (lastSlash <= 0) {
+        return null;
+    }
+    return filePath.substring(0, lastSlash);
+}
+
+/**
+ * Creates Actor folders to mirror the vault folder structure.
+ * @param {StatblockData[]} statblocks - Array of parsed statblocks
+ * @param {string} vaultRoot - Vault root path to strip (e.g., "Cormyr A Campaign/")
+ * @param {string[]} createdFolderIds - Array to track created folder IDs for rollback
+ * @returns {Promise<Map<string, Folder>>} Map of path to Folder
+ */
+async function createActorFolders(statblocks, vaultRoot, createdFolderIds) {
+    const folderMap = new Map();
+
+    const folderPaths = new Set();
+    for (const statblock of statblocks) {
+        let filePath = statblock.filePath;
+        if (vaultRoot && filePath.startsWith(vaultRoot)) {
+            filePath = filePath.substring(vaultRoot.length);
+        }
+        const parentPath = getParentPath(filePath);
+        if (parentPath) {
+            const parts = parentPath.split('/');
+            for (let i = 1; i <= parts.length; i++) {
+                folderPaths.add(parts.slice(0, i).join('/'));
+            }
+        }
+    }
+
+    if (folderPaths.size === 0) {
+        return folderMap;
+    }
+
+    const sortedPaths = Array.from(folderPaths).sort((a, b) => {
+        return a.split('/').length - b.split('/').length;
+    });
+
+    const existingFoldersIndex = new Map();
+    for (const folder of game.folders.filter(f => f.type === 'Actor')) {
+        const key = `${folder.folder?.id ?? null}:${folder.name}`;
+        existingFoldersIndex.set(key, folder);
+    }
+
+    for (const path of sortedPaths) {
+        const parts = path.split('/');
+        const name = parts[parts.length - 1];
+        const parentPath = parts.length > 1 ? parts.slice(0, -1).join('/') : null;
+        const parentId = parentPath ? folderMap.get(parentPath)?.id : null;
+
+        const lookupKey = `${parentId}:${name}`;
+        const existing = existingFoldersIndex.get(lookupKey);
+
+        if (existing) {
+            folderMap.set(path, existing);
+            continue;
+        }
+
+        const folder = await Folder.create({
+            name,
+            type: 'Actor',
+            folder: parentId
+        });
+
+        if (folder) {
+            folderMap.set(path, folder);
+            createdFolderIds.push(folder.id);
+            // Add to index so child folders can find it
+            existingFoldersIndex.set(`${parentId}:${name}`, folder);
+        }
+    }
+
+    return folderMap;
+}
 
 /**
  * Creates a configured pipeline for importing an Obsidian vault into Foundry.
@@ -23,19 +113,22 @@ import ConflictDialog from '../ui/ConflictDialog.js';
  * Pipeline phases:
  * 1. Filter files - Select files based on tree selection
  * 2. Prepare documents - Read file content and create MarkdownFile objects
- * 3. Extract frontmatter - Extract YAML frontmatter before markdown processing
- * 4. Extract callouts - Extract Obsidian callouts and replace with placeholders
- * 5. Convert line breaks - Convert single newlines to <br /> (conditional on strictLineBreaks)
- * 6. Replace callouts - Replace callout placeholders with rendered HTML
- * 7. Extract references - Extract links and assets from markdown
- * 8. Replace references - Replace references with placeholders
- * 9. Convert markdown - Convert markdown text to HTML
- * 10. Plan structure - Determine folder and journal entry structure
- * 11. Detect conflicts - Check for pages modified since last sync, prompt user
- * 12. Create documents - Create Foundry folders, journal entries, and pages
- * 13. Upload assets - Upload non-markdown files to data path (conditional)
- * 14. Resolve placeholders - Replace placeholders with actual UUIDs and paths
- * 15. Update content - Write final HTML content to journal pages
+ * 3. Prepare statblocks - Extract and parse statblock code blocks (conditional)
+ * 4. Detect statblock conflicts - Check for existing actors (conditional)
+ * 5. Import statblock actors - Create/update Actor documents (conditional)
+ * 6. Extract frontmatter - Extract YAML frontmatter before markdown processing
+ * 7. Extract callouts - Extract Obsidian callouts and replace with placeholders
+ * 8. Convert line breaks - Convert single newlines to <br /> (conditional on strictLineBreaks)
+ * 9. Replace callouts - Replace callout placeholders with rendered HTML
+ * 10. Extract references - Extract links and assets from markdown
+ * 11. Replace references - Replace references with placeholders
+ * 12. Convert markdown - Convert markdown text to HTML
+ * 13. Plan structure - Determine folder and journal entry structure
+ * 14. Detect conflicts - Check for pages modified since last sync, prompt user
+ * 15. Create documents - Create Foundry folders, journal entries, and pages
+ * 16. Upload assets - Upload non-markdown files to data path (conditional)
+ * 17. Resolve placeholders - Replace placeholders with actual UUIDs and paths
+ * 18. Update content - Write final HTML content to journal pages
  *
  * @param {import('../domain/ImportOptions').default} importOptions - Import configuration
  * @param {import('showdown').Converter} showdownConverter - Markdown to HTML converter
@@ -50,6 +143,7 @@ export default function createImportPipeline(importOptions, showdownConverter) {
         markdownFiles: null,
         structurePlan: null,
         callouts: new Map(),
+        statblocks: [],
     };
 
     const phases = [
@@ -79,6 +173,151 @@ export default function createImportPipeline(importOptions, showdownConverter) {
                 const markdownFiles = await prepareFilesForImport(ctx.filesToParse);
                 ctx.markdownFiles = markdownFiles;
                 return { markdownFiles: markdownFiles.length };
+            }
+        }),
+
+        new PhaseDefinition({
+            name: 'prepare-statblocks',
+            condition: ctx => {
+                const result = ctx.importOptions.importStatblocks && StatblockAdapterRegistry.isAvailable();
+                console.log('Obsidian Bridge | prepare-statblocks condition:', {
+                    importStatblocks: ctx.importOptions.importStatblocks,
+                    isAvailable: StatblockAdapterRegistry.isAvailable(),
+                    result
+                });
+                return result;
+            },
+            execute: async ctx => {
+                console.log('Obsidian Bridge | prepare-statblocks executing, files:', ctx.markdownFiles.length);
+                let parsed = 0;
+
+                for (const markdownFile of ctx.markdownFiles) {
+                    const blocks = extractStatblocks(markdownFile.content);
+                    console.log('Obsidian Bridge | File:', markdownFile.filePath, 'blocks found:', blocks.length);
+
+                    for (const block of blocks) {
+                        const statblock = parseStatblock(block.yaml, markdownFile.filePath);
+                        ctx.statblocks.push(statblock);
+                        parsed++;
+                    }
+                }
+
+                console.log('Obsidian Bridge | prepare-statblocks complete, parsed:', parsed);
+                return { parsed };
+            }
+        }),
+
+        new PhaseDefinition({
+            name: 'detect-statblock-conflicts',
+            condition: ctx => ctx.importOptions.importStatblocks && StatblockAdapterRegistry.isAvailable(),
+            execute: async ctx => {
+                if (!ctx.statblocks?.length) {
+                    console.log('Obsidian Bridge | detect-statblock-conflicts skipping, no statblocks');
+                    return { toCreate: [], toUpdate: [], toSkip: [] };
+                }
+                console.log('Obsidian Bridge | detect-statblock-conflicts executing, statblocks:', ctx.statblocks.length);
+                const toCreate = [];
+                const toUpdate = [];
+                const toSkip = [];
+
+                for (const statblock of ctx.statblocks) {
+                    const existingByFlag = game.actors.find(actor =>
+                        actor.flags[MODULE_ID]?.sourceFile === statblock.filePath
+                        && actor.name === statblock.name
+                    );
+
+                    if (existingByFlag) {
+                        statblock._action = 'update';
+                        statblock._existingActor = existingByFlag;
+                        toUpdate.push(statblock.name);
+                        continue;
+                    }
+
+                    const existingByName = game.actors.find(actor =>
+                        actor.name === statblock.name
+                        && !actor.flags[MODULE_ID]?.sourceFile
+                    );
+
+                    if (existingByName) {
+                        statblock._action = 'skip';
+                        toSkip.push(statblock.name);
+                        continue;
+                    }
+
+                    statblock._action = 'create';
+                    toCreate.push(statblock.name);
+                }
+
+                return { toCreate, toUpdate, toSkip };
+            }
+        }),
+
+        new PhaseDefinition({
+            name: 'import-statblock-actors',
+            condition: ctx => ctx.importOptions.importStatblocks && StatblockAdapterRegistry.isAvailable(),
+            execute: async ctx => {
+                if (!ctx.statblocks?.length) {
+                    console.log('Obsidian Bridge | import-statblock-actors skipping, no statblocks');
+                    return {
+                        created: [], updated: [], skipped: 0,
+                        actors: [], createdActorIds: [], createdFolderIds: []
+                    };
+                }
+                console.log('Obsidian Bridge | import-statblock-actors executing');
+                const adapter = StatblockAdapterRegistry.getAdapter();
+                console.log('Obsidian Bridge | adapter:', adapter ? 'found' : 'NOT FOUND');
+                const created = [];
+                const updated = [];
+                let skipped = 0;
+                const actors = [];
+                const createdActorIds = [];
+                const createdFolderIds = [];
+
+                const vaultRoot = ctx.importOptions.vaultPath ? `${ctx.importOptions.vaultPath}/` : '';
+                const folderMap = await createActorFolders(ctx.statblocks, vaultRoot, createdFolderIds);
+
+                for (const statblock of ctx.statblocks) {
+                    if (statblock._action === 'skip') {
+                        skipped++;
+                        continue;
+                    }
+
+                    if (statblock._action === 'update') {
+                        const actor = await adapter.updateActor(statblock._existingActor, statblock);
+                        updated.push(statblock.name);
+                        actors.push({ actor, wasCreated: false });
+                        continue;
+                    }
+
+                    let filePath = statblock.filePath;
+                    if (vaultRoot && filePath.startsWith(vaultRoot)) {
+                        filePath = filePath.substring(vaultRoot.length);
+                    }
+                    const folderPath = getParentPath(filePath);
+                    const folder = folderPath ? folderMap.get(folderPath) : null;
+
+                    const actor = await adapter.createActor(statblock, { folder });
+                    created.push(statblock.name);
+                    actors.push({ actor, wasCreated: true });
+                    createdActorIds.push(actor.id);
+                }
+
+                return { created, updated, skipped, actors, createdActorIds, createdFolderIds };
+            },
+            rollback: async (ctx, result) => {
+                for (const actorId of result?.createdActorIds || []) {
+                    const actor = game.actors.get(actorId);
+                    if (actor) {
+                        await actor.delete();
+                    }
+                }
+
+                for (const folderId of (result?.createdFolderIds || []).reverse()) {
+                    const folder = game.folders.get(folderId);
+                    if (folder) {
+                        await folder.delete();
+                    }
+                }
             }
         }),
 

--- a/src/statblock/adapters/dnd5e/actionParser.js
+++ b/src/statblock/adapters/dnd5e/actionParser.js
@@ -1,47 +1,37 @@
 /**
  * Parses action descriptions to extract attack data.
- * Handles Fantasy Statblocks action format.
  */
 
 /**
- * Attack data extracted from an action description.
  * @typedef {Object} ParsedAttack
- * @property {boolean} isAttack - Whether this is an attack action
+ * @property {boolean} isAttack
  * @property {string} attackType - 'mwak', 'rwak', 'msak', 'rsak', or null
- * @property {boolean} isMelee - Has melee capability
- * @property {boolean} isRanged - Has ranged capability
- * @property {boolean} isWeapon - Is a weapon attack (vs spell attack)
- * @property {number|null} attackBonus - Attack bonus (e.g., +5 -> 5)
- * @property {number|null} reach - Reach in feet for melee
- * @property {number|null} range - Short range for ranged
- * @property {number|null} longRange - Long range for ranged
- * @property {string|null} damageFormula - Damage dice (e.g., "2d6 + 3")
- * @property {string|null} damageType - Damage type (e.g., "slashing")
- * @property {string} description - Original full description
+ * @property {boolean} isMelee
+ * @property {boolean} isRanged
+ * @property {boolean} isWeapon
+ * @property {number|null} attackBonus
+ * @property {number|null} reach
+ * @property {number|null} range
+ * @property {number|null} longRange
+ * @property {string|null} damageFormula
+ * @property {string|null} damageType
+ * @property {string} description
  */
 
-/**
- * Regex patterns for parsing attack descriptions.
- */
 const ATTACK_TYPE_PATTERN = /_(Melee|Ranged|Melee or Ranged)\s*(Weapon\s*)?Attack(?:\s*Roll)?:?_\s*\+?(\d+)/i;
 const REACH_PATTERN = /reach\s+(\d+)\s*ft/i;
 const RANGE_PATTERN = /range\s+(\d+)(?:\/(\d+))?\s*(?:ft)?/i;
 const HIT_PATTERN = /_Hit:?_\s*(?:\d+\s*)?(?:\()?(\d+d\d+(?:\s*[+-]\s*\d+)?)\)?(?:\s+(\w+))?\s*damage/i;
 const DAMAGE_TYPE_PATTERN = /(\d+d\d+(?:\s*[+-]\s*\d+)?)\)?\s+(\w+)\s+damage/i;
 
-/**
- * Valid damage types in 5e.
- */
 const DAMAGE_TYPES = new Set([
     'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
     'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder'
 ]);
 
 /**
- * Parses an action description to extract attack data.
- *
- * @param {string} desc - The action description
- * @returns {ParsedAttack} Parsed attack data
+ * @param {string} desc
+ * @returns {ParsedAttack}
  */
 export function parseAttackAction(desc) {
     const result = {
@@ -63,7 +53,6 @@ export function parseAttackAction(desc) {
         return result;
     }
 
-    // Check for attack pattern
     const attackMatch = desc.match(ATTACK_TYPE_PATTERN);
     if (!attackMatch) {
         return result;
@@ -74,7 +63,6 @@ export function parseAttackAction(desc) {
     const isWeaponStr = attackMatch[2];
     result.attackBonus = parseInt(attackMatch[3], 10);
 
-    // Determine melee/ranged
     if (attackTypeStr.includes('melee')) {
         result.isMelee = true;
     }
@@ -82,12 +70,9 @@ export function parseAttackAction(desc) {
         result.isRanged = true;
     }
 
-    // Determine weapon vs spell
     result.isWeapon = !!isWeaponStr || attackTypeStr.includes('weapon');
 
-    // Set attack type code
     if (result.isMelee && result.isRanged) {
-        // Versatile - defaults to melee weapon
         result.attackType = result.isWeapon ? 'mwak' : 'msak';
     } else if (result.isMelee) {
         result.attackType = result.isWeapon ? 'mwak' : 'msak';
@@ -95,13 +80,11 @@ export function parseAttackAction(desc) {
         result.attackType = result.isWeapon ? 'rwak' : 'rsak';
     }
 
-    // Extract reach
     const reachMatch = desc.match(REACH_PATTERN);
     if (reachMatch) {
         result.reach = parseInt(reachMatch[1], 10);
     }
 
-    // Extract range
     const rangeMatch = desc.match(RANGE_PATTERN);
     if (rangeMatch) {
         result.range = parseInt(rangeMatch[1], 10);
@@ -110,37 +93,18 @@ export function parseAttackAction(desc) {
         }
     }
 
-    // Extract damage
-    const damageMatch = desc.match(DAMAGE_TYPE_PATTERN);
+    const damageMatch = desc.match(DAMAGE_TYPE_PATTERN) || desc.match(HIT_PATTERN);
     if (damageMatch) {
         result.damageFormula = damageMatch[1].replace(/\s+/g, '');
-        const potentialType = damageMatch[2].toLowerCase();
-        if (DAMAGE_TYPES.has(potentialType)) {
+        const potentialType = damageMatch[2]?.toLowerCase();
+        if (potentialType && DAMAGE_TYPES.has(potentialType)) {
             result.damageType = potentialType;
-        }
-    } else {
-        // Try simpler pattern
-        const hitMatch = desc.match(HIT_PATTERN);
-        if (hitMatch) {
-            result.damageFormula = hitMatch[1].replace(/\s+/g, '');
-            if (hitMatch[2]) {
-                const potentialType = hitMatch[2].toLowerCase();
-                if (DAMAGE_TYPES.has(potentialType)) {
-                    result.damageType = potentialType;
-                }
-            }
         }
     }
 
     return result;
 }
 
-/**
- * Determines if an action is a multiattack action.
- *
- * @param {Object} action - Action object with name and desc
- * @returns {boolean} True if this is a multiattack
- */
 export function isMultiattack(action) {
     if (!action?.name) {
         return false;
@@ -148,26 +112,15 @@ export function isMultiattack(action) {
     return action.name.toLowerCase().includes('multiattack');
 }
 
-/**
- * Extracts the weapon name from an action, if it appears to be a weapon.
- * This is used for compendium lookups.
- *
- * @param {string} name - Action name (e.g., "Longsword", "Javelin")
- * @returns {string} Normalized weapon name for lookup
- */
 export function extractWeaponName(name) {
     if (!name) {
         return '';
     }
-    // Remove common suffixes/prefixes that aren't part of weapon names
     return name
-        .replace(/\s*\(.*\)$/, '') // Remove parenthetical notes
+        .replace(/\s*\(.*\)$/, '')
         .trim();
 }
 
-/**
- * Ability name to abbreviation mapping.
- */
 const ABILITY_MAP = {
     strength: 'str',
     dexterity: 'dex',
@@ -177,40 +130,20 @@ const ABILITY_MAP = {
     charisma: 'cha'
 };
 
-/**
- * Saving throw patterns.
- */
 const SAVE_PATTERNS = [
-    // "_Dexterity Saving Throw:_ DC 16" - Fantasy Statblocks format
     /_(\w+)\s+Saving\s+Throw:?_\s*DC\s*(\d+)/i,
-    // "DC 16 Dexterity saving throw"
     /DC\s*(\d+)\s+(\w+)\s+saving\s+throw/i,
-    // "Dexterity saving throw (DC 16)" or "Dexterity save (DC 16)"
     /(\w+)\s+sav(?:ing\s+throw|e)\s*\(DC\s*(\d+)\)/i,
-    // "must succeed on a DC 16 Dexterity saving throw"
     /DC\s*(\d+)\s+(\w+)\s+sav(?:ing\s+throw|e)/i
 ];
 
 /**
- * Parsed save data from an action description.
  * @typedef {Object} ParsedSave
- * @property {boolean} isSave - Whether this action requires a saving throw
- * @property {string|null} ability - Save ability abbreviation (str, dex, etc.)
- * @property {number|null} dc - Save DC
+ * @property {boolean} isSave
+ * @property {string|null} ability
+ * @property {number|null} dc
  */
 
-/**
- * Parses an action description to extract saving throw data.
- *
- * @param {string} desc - The action description
- * @returns {ParsedSave} Parsed save data
- */
-/**
- * Parses recharge and limited use info from an action name.
- *
- * @param {string} name - Action name (e.g., "Breath Weapon (Recharge 5-6)" or "Protective Magic (3/Day)")
- * @returns {{hasRecharge: boolean, rechargeValue: number|null, hasUses: boolean, usesValue: number|null, usesPeriod: string|null, cleanName: string}}
- */
 export function parseRecharge(name) {
     const result = {
         hasRecharge: false,
@@ -225,7 +158,6 @@ export function parseRecharge(name) {
         return result;
     }
 
-    // Match "Recharge 5-6" or "Recharge 6"
     const rechargeMatch = name.match(/\s*\(Recharge\s+(\d)(?:-6)?\)\s*$/i);
     if (rechargeMatch) {
         result.hasRecharge = true;
@@ -234,7 +166,6 @@ export function parseRecharge(name) {
         return result;
     }
 
-    // Match "3/Day", "1/Day", "3/day each", "1/Short Rest", "1/Long Rest"
     const usesMatch = name.match(/\s*\((\d+)\/(Day|Short Rest|Long Rest)(?:\s+Each)?\)\s*$/i);
     if (usesMatch) {
         result.hasUses = true;
@@ -269,7 +200,6 @@ export function parseSaveAction(desc) {
         if (match) {
             result.isSave = true;
 
-            // Pattern order varies - some have DC first, some have ability first
             if (/^\d+$/.test(match[1])) {
                 result.dc = parseInt(match[1], 10);
                 const abilityName = match[2].toLowerCase();
@@ -286,13 +216,6 @@ export function parseSaveAction(desc) {
     return result;
 }
 
-/**
- * Parses damage from a description that isn't an attack.
- * Matches patterns like "2 (1d4) damage" or "1d6 fire damage".
- *
- * @param {string} desc - The description text
- * @returns {{hasDamage: boolean, formula: string|null, type: string|null}}
- */
 export function parseDamageFromDescription(desc) {
     const result = {
         hasDamage: false,
@@ -304,9 +227,7 @@ export function parseDamageFromDescription(desc) {
         return result;
     }
 
-    // Pattern: "2 (1d4) damage" or "2 (1d4) fire damage"
     const parenPattern = /(\d+)\s*\((\d+d\d+(?:\s*[+-]\s*\d+)?)\)\s*(\w+)?\s*damage/i;
-    // Pattern: "1d6 damage" or "1d6 fire damage"
     const simplePattern = /(\d+d\d+(?:\s*[+-]\s*\d+)?)\s+(\w+)?\s*damage/i;
 
     let match = desc.match(parenPattern);
@@ -332,19 +253,12 @@ export function parseDamageFromDescription(desc) {
 }
 
 /**
- * Parsed reaction trigger/response data.
  * @typedef {Object} ParsedReaction
- * @property {boolean} hasTrigger - Whether this has a trigger/response format
- * @property {string|null} trigger - The trigger text (activation condition)
- * @property {string|null} response - The response text (description body)
+ * @property {boolean} hasTrigger
+ * @property {string|null} trigger
+ * @property {string|null} response
  */
 
-/**
- * Parses a reaction description to extract trigger and response.
- *
- * @param {string} desc - The reaction description
- * @returns {ParsedReaction} Parsed reaction data
- */
 export function parseReactionTrigger(desc) {
     const result = {
         hasTrigger: false,
@@ -368,9 +282,6 @@ export function parseReactionTrigger(desc) {
     return result;
 }
 
-/**
- * Area type mappings from common terms to dnd5e keys.
- */
 const AREA_TYPE_MAP = {
     emanation: 'radius',
     sphere: 'sphere',
@@ -384,22 +295,15 @@ const AREA_TYPE_MAP = {
 };
 
 /**
- * Parsed targeting data from an action description.
  * @typedef {Object} ParsedTarget
- * @property {string|null} areaType - Area template type (radius, sphere, cone, etc.)
- * @property {number|null} areaSize - Size of the area in feet
- * @property {number|null} range - Range in feet
- * @property {number|null} longRange - Long range in feet (for ranged abilities)
- * @property {string|null} affectsType - Type of targets (creature, ally, enemy, willing)
- * @property {number|null} affectsCount - Number of targets (null for area effects)
+ * @property {string|null} areaType
+ * @property {number|null} areaSize
+ * @property {number|null} range
+ * @property {number|null} longRange
+ * @property {string|null} affectsType
+ * @property {number|null} affectsCount
  */
 
-/**
- * Parses an action description to extract targeting data.
- *
- * @param {string} desc - The action description
- * @returns {ParsedTarget} Parsed targeting data
- */
 export function parseTargeting(desc) {
     const result = {
         areaType: null,
@@ -454,7 +358,6 @@ export function parseTargeting(desc) {
         }
     }
 
-    // Order matters - check specific patterns before general ones
     if (/\ball\s+hostile\s+creatures?\b/i.test(desc)) {
         result.affectsType = 'enemy';
         result.affectsCount = null;

--- a/src/statblock/adapters/dnd5e/actionParser.js
+++ b/src/statblock/adapters/dnd5e/actionParser.js
@@ -1,0 +1,476 @@
+/**
+ * Parses action descriptions to extract attack data.
+ * Handles Fantasy Statblocks action format.
+ */
+
+/**
+ * Attack data extracted from an action description.
+ * @typedef {Object} ParsedAttack
+ * @property {boolean} isAttack - Whether this is an attack action
+ * @property {string} attackType - 'mwak', 'rwak', 'msak', 'rsak', or null
+ * @property {boolean} isMelee - Has melee capability
+ * @property {boolean} isRanged - Has ranged capability
+ * @property {boolean} isWeapon - Is a weapon attack (vs spell attack)
+ * @property {number|null} attackBonus - Attack bonus (e.g., +5 -> 5)
+ * @property {number|null} reach - Reach in feet for melee
+ * @property {number|null} range - Short range for ranged
+ * @property {number|null} longRange - Long range for ranged
+ * @property {string|null} damageFormula - Damage dice (e.g., "2d6 + 3")
+ * @property {string|null} damageType - Damage type (e.g., "slashing")
+ * @property {string} description - Original full description
+ */
+
+/**
+ * Regex patterns for parsing attack descriptions.
+ */
+const ATTACK_TYPE_PATTERN = /_(Melee|Ranged|Melee or Ranged)\s*(Weapon\s*)?Attack(?:\s*Roll)?:?_\s*\+?(\d+)/i;
+const REACH_PATTERN = /reach\s+(\d+)\s*ft/i;
+const RANGE_PATTERN = /range\s+(\d+)(?:\/(\d+))?\s*(?:ft)?/i;
+const HIT_PATTERN = /_Hit:?_\s*(?:\d+\s*)?(?:\()?(\d+d\d+(?:\s*[+-]\s*\d+)?)\)?(?:\s+(\w+))?\s*damage/i;
+const DAMAGE_TYPE_PATTERN = /(\d+d\d+(?:\s*[+-]\s*\d+)?)\)?\s+(\w+)\s+damage/i;
+
+/**
+ * Valid damage types in 5e.
+ */
+const DAMAGE_TYPES = new Set([
+    'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
+    'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder'
+]);
+
+/**
+ * Parses an action description to extract attack data.
+ *
+ * @param {string} desc - The action description
+ * @returns {ParsedAttack} Parsed attack data
+ */
+export function parseAttackAction(desc) {
+    const result = {
+        isAttack: false,
+        attackType: null,
+        isMelee: false,
+        isRanged: false,
+        isWeapon: false,
+        attackBonus: null,
+        reach: null,
+        range: null,
+        longRange: null,
+        damageFormula: null,
+        damageType: null,
+        description: desc || ''
+    };
+
+    if (!desc) {
+        return result;
+    }
+
+    // Check for attack pattern
+    const attackMatch = desc.match(ATTACK_TYPE_PATTERN);
+    if (!attackMatch) {
+        return result;
+    }
+
+    result.isAttack = true;
+    const attackTypeStr = attackMatch[1].toLowerCase();
+    const isWeaponStr = attackMatch[2];
+    result.attackBonus = parseInt(attackMatch[3], 10);
+
+    // Determine melee/ranged
+    if (attackTypeStr.includes('melee')) {
+        result.isMelee = true;
+    }
+    if (attackTypeStr.includes('ranged')) {
+        result.isRanged = true;
+    }
+
+    // Determine weapon vs spell
+    result.isWeapon = !!isWeaponStr || attackTypeStr.includes('weapon');
+
+    // Set attack type code
+    if (result.isMelee && result.isRanged) {
+        // Versatile - defaults to melee weapon
+        result.attackType = result.isWeapon ? 'mwak' : 'msak';
+    } else if (result.isMelee) {
+        result.attackType = result.isWeapon ? 'mwak' : 'msak';
+    } else if (result.isRanged) {
+        result.attackType = result.isWeapon ? 'rwak' : 'rsak';
+    }
+
+    // Extract reach
+    const reachMatch = desc.match(REACH_PATTERN);
+    if (reachMatch) {
+        result.reach = parseInt(reachMatch[1], 10);
+    }
+
+    // Extract range
+    const rangeMatch = desc.match(RANGE_PATTERN);
+    if (rangeMatch) {
+        result.range = parseInt(rangeMatch[1], 10);
+        if (rangeMatch[2]) {
+            result.longRange = parseInt(rangeMatch[2], 10);
+        }
+    }
+
+    // Extract damage
+    const damageMatch = desc.match(DAMAGE_TYPE_PATTERN);
+    if (damageMatch) {
+        result.damageFormula = damageMatch[1].replace(/\s+/g, '');
+        const potentialType = damageMatch[2].toLowerCase();
+        if (DAMAGE_TYPES.has(potentialType)) {
+            result.damageType = potentialType;
+        }
+    } else {
+        // Try simpler pattern
+        const hitMatch = desc.match(HIT_PATTERN);
+        if (hitMatch) {
+            result.damageFormula = hitMatch[1].replace(/\s+/g, '');
+            if (hitMatch[2]) {
+                const potentialType = hitMatch[2].toLowerCase();
+                if (DAMAGE_TYPES.has(potentialType)) {
+                    result.damageType = potentialType;
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Determines if an action is a multiattack action.
+ *
+ * @param {Object} action - Action object with name and desc
+ * @returns {boolean} True if this is a multiattack
+ */
+export function isMultiattack(action) {
+    if (!action?.name) {
+        return false;
+    }
+    return action.name.toLowerCase().includes('multiattack');
+}
+
+/**
+ * Extracts the weapon name from an action, if it appears to be a weapon.
+ * This is used for compendium lookups.
+ *
+ * @param {string} name - Action name (e.g., "Longsword", "Javelin")
+ * @returns {string} Normalized weapon name for lookup
+ */
+export function extractWeaponName(name) {
+    if (!name) {
+        return '';
+    }
+    // Remove common suffixes/prefixes that aren't part of weapon names
+    return name
+        .replace(/\s*\(.*\)$/, '') // Remove parenthetical notes
+        .trim();
+}
+
+/**
+ * Ability name to abbreviation mapping.
+ */
+const ABILITY_MAP = {
+    strength: 'str',
+    dexterity: 'dex',
+    constitution: 'con',
+    intelligence: 'int',
+    wisdom: 'wis',
+    charisma: 'cha'
+};
+
+/**
+ * Saving throw patterns.
+ */
+const SAVE_PATTERNS = [
+    // "_Dexterity Saving Throw:_ DC 16" - Fantasy Statblocks format
+    /_(\w+)\s+Saving\s+Throw:?_\s*DC\s*(\d+)/i,
+    // "DC 16 Dexterity saving throw"
+    /DC\s*(\d+)\s+(\w+)\s+saving\s+throw/i,
+    // "Dexterity saving throw (DC 16)" or "Dexterity save (DC 16)"
+    /(\w+)\s+sav(?:ing\s+throw|e)\s*\(DC\s*(\d+)\)/i,
+    // "must succeed on a DC 16 Dexterity saving throw"
+    /DC\s*(\d+)\s+(\w+)\s+sav(?:ing\s+throw|e)/i
+];
+
+/**
+ * Parsed save data from an action description.
+ * @typedef {Object} ParsedSave
+ * @property {boolean} isSave - Whether this action requires a saving throw
+ * @property {string|null} ability - Save ability abbreviation (str, dex, etc.)
+ * @property {number|null} dc - Save DC
+ */
+
+/**
+ * Parses an action description to extract saving throw data.
+ *
+ * @param {string} desc - The action description
+ * @returns {ParsedSave} Parsed save data
+ */
+/**
+ * Parses recharge and limited use info from an action name.
+ *
+ * @param {string} name - Action name (e.g., "Breath Weapon (Recharge 5-6)" or "Protective Magic (3/Day)")
+ * @returns {{hasRecharge: boolean, rechargeValue: number|null, hasUses: boolean, usesValue: number|null, usesPeriod: string|null, cleanName: string}}
+ */
+export function parseRecharge(name) {
+    const result = {
+        hasRecharge: false,
+        rechargeValue: null,
+        hasUses: false,
+        usesValue: null,
+        usesPeriod: null,
+        cleanName: name || ''
+    };
+
+    if (!name) {
+        return result;
+    }
+
+    // Match "Recharge 5-6" or "Recharge 6"
+    const rechargeMatch = name.match(/\s*\(Recharge\s+(\d)(?:-6)?\)\s*$/i);
+    if (rechargeMatch) {
+        result.hasRecharge = true;
+        result.rechargeValue = parseInt(rechargeMatch[1], 10);
+        result.cleanName = name.replace(/\s*\(Recharge\s+\d(?:-6)?\)\s*$/i, '').trim();
+        return result;
+    }
+
+    // Match "3/Day", "1/Day", "3/day each", "1/Short Rest", "1/Long Rest"
+    const usesMatch = name.match(/\s*\((\d+)\/(Day|Short Rest|Long Rest)(?:\s+Each)?\)\s*$/i);
+    if (usesMatch) {
+        result.hasUses = true;
+        result.usesValue = parseInt(usesMatch[1], 10);
+        const period = usesMatch[2].toLowerCase();
+        if (period === 'day') {
+            result.usesPeriod = 'day';
+        } else if (period === 'short rest') {
+            result.usesPeriod = 'sr';
+        } else if (period === 'long rest') {
+            result.usesPeriod = 'lr';
+        }
+        result.cleanName = name.replace(/\s*\(\d+\/(?:Day|Short Rest|Long Rest)(?:\s+Each)?\)\s*$/i, '').trim();
+    }
+
+    return result;
+}
+
+export function parseSaveAction(desc) {
+    const result = {
+        isSave: false,
+        ability: null,
+        dc: null
+    };
+
+    if (!desc) {
+        return result;
+    }
+
+    for (const pattern of SAVE_PATTERNS) {
+        const match = desc.match(pattern);
+        if (match) {
+            result.isSave = true;
+
+            // Pattern order varies - some have DC first, some have ability first
+            if (/^\d+$/.test(match[1])) {
+                result.dc = parseInt(match[1], 10);
+                const abilityName = match[2].toLowerCase();
+                result.ability = ABILITY_MAP[abilityName] || abilityName.substring(0, 3);
+            } else {
+                const abilityName = match[1].toLowerCase();
+                result.ability = ABILITY_MAP[abilityName] || abilityName.substring(0, 3);
+                result.dc = parseInt(match[2], 10);
+            }
+            break;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Parses damage from a description that isn't an attack.
+ * Matches patterns like "2 (1d4) damage" or "1d6 fire damage".
+ *
+ * @param {string} desc - The description text
+ * @returns {{hasDamage: boolean, formula: string|null, type: string|null}}
+ */
+export function parseDamageFromDescription(desc) {
+    const result = {
+        hasDamage: false,
+        formula: null,
+        type: null
+    };
+
+    if (!desc) {
+        return result;
+    }
+
+    // Pattern: "2 (1d4) damage" or "2 (1d4) fire damage"
+    const parenPattern = /(\d+)\s*\((\d+d\d+(?:\s*[+-]\s*\d+)?)\)\s*(\w+)?\s*damage/i;
+    // Pattern: "1d6 damage" or "1d6 fire damage"
+    const simplePattern = /(\d+d\d+(?:\s*[+-]\s*\d+)?)\s+(\w+)?\s*damage/i;
+
+    let match = desc.match(parenPattern);
+    if (match) {
+        result.hasDamage = true;
+        result.formula = match[2].replace(/\s+/g, '');
+        if (match[3] && DAMAGE_TYPES.has(match[3].toLowerCase())) {
+            result.type = match[3].toLowerCase();
+        }
+        return result;
+    }
+
+    match = desc.match(simplePattern);
+    if (match) {
+        result.hasDamage = true;
+        result.formula = match[1].replace(/\s+/g, '');
+        if (match[2] && DAMAGE_TYPES.has(match[2].toLowerCase())) {
+            result.type = match[2].toLowerCase();
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Parsed reaction trigger/response data.
+ * @typedef {Object} ParsedReaction
+ * @property {boolean} hasTrigger - Whether this has a trigger/response format
+ * @property {string|null} trigger - The trigger text (activation condition)
+ * @property {string|null} response - The response text (description body)
+ */
+
+/**
+ * Parses a reaction description to extract trigger and response.
+ *
+ * @param {string} desc - The reaction description
+ * @returns {ParsedReaction} Parsed reaction data
+ */
+export function parseReactionTrigger(desc) {
+    const result = {
+        hasTrigger: false,
+        trigger: null,
+        response: null
+    };
+
+    if (!desc) {
+        return result;
+    }
+
+    const pattern = /_Trigger:_\s*(.+?)\s*_Response:_\s*(.+)$/is;
+    const match = desc.match(pattern);
+
+    if (match) {
+        result.hasTrigger = true;
+        result.trigger = match[1].trim();
+        result.response = match[2].trim();
+    }
+
+    return result;
+}
+
+/**
+ * Area type mappings from common terms to dnd5e keys.
+ */
+const AREA_TYPE_MAP = {
+    emanation: 'radius',
+    sphere: 'sphere',
+    cone: 'cone',
+    cube: 'cube',
+    cylinder: 'cylinder',
+    line: 'line',
+    square: 'square',
+    circle: 'circle',
+    wall: 'wall'
+};
+
+/**
+ * Parsed targeting data from an action description.
+ * @typedef {Object} ParsedTarget
+ * @property {string|null} areaType - Area template type (radius, sphere, cone, etc.)
+ * @property {number|null} areaSize - Size of the area in feet
+ * @property {number|null} range - Range in feet
+ * @property {number|null} longRange - Long range in feet (for ranged abilities)
+ * @property {string|null} affectsType - Type of targets (creature, ally, enemy, willing)
+ * @property {number|null} affectsCount - Number of targets (null for area effects)
+ */
+
+/**
+ * Parses an action description to extract targeting data.
+ *
+ * @param {string} desc - The action description
+ * @returns {ParsedTarget} Parsed targeting data
+ */
+export function parseTargeting(desc) {
+    const result = {
+        areaType: null,
+        areaSize: null,
+        range: null,
+        longRange: null,
+        affectsType: null,
+        affectsCount: null
+    };
+
+    if (!desc) {
+        return result;
+    }
+
+    const areaPatterns = [
+        /(\d+)[- ]foot[- ]?(emanation|sphere|cone|cube|cylinder|line|square|circle|wall)/i,
+        /(\d+)[- ]foot[- ]?radius\s+(sphere|cylinder|circle)/i,
+        /(emanation|sphere|cone|cube|cylinder|line)\s+of\s+(\d+)\s*(?:feet|ft)/i
+    ];
+
+    for (const pattern of areaPatterns) {
+        const match = desc.match(pattern);
+        if (match) {
+            if (/^\d+$/.test(match[1])) {
+                result.areaSize = parseInt(match[1], 10);
+                const areaKey = match[2].toLowerCase();
+                result.areaType = AREA_TYPE_MAP[areaKey] || areaKey;
+            } else {
+                const areaKey = match[1].toLowerCase();
+                result.areaType = AREA_TYPE_MAP[areaKey] || areaKey;
+                result.areaSize = parseInt(match[2], 10);
+            }
+            break;
+        }
+    }
+
+    const rangePatterns = [
+        /within\s+(\d+)\s*(?:feet|ft)/i,
+        /between\s+(\d+)\s+and\s+(\d+)\s*(?:feet|ft)/i,
+        /up\s+to\s+(\d+)\s*(?:feet|ft)/i,
+        /can\s+see\s+within\s+(\d+)\s*(?:feet|ft)/i
+    ];
+
+    for (const pattern of rangePatterns) {
+        const match = desc.match(pattern);
+        if (match) {
+            result.range = parseInt(match[1], 10);
+            if (match[2]) {
+                result.longRange = parseInt(match[2], 10);
+            }
+            break;
+        }
+    }
+
+    // Order matters - check specific patterns before general ones
+    if (/\ball\s+hostile\s+creatures?\b/i.test(desc)) {
+        result.affectsType = 'enemy';
+        result.affectsCount = null;
+    } else if (/\ball\s+creatures?\b/i.test(desc)) {
+        result.affectsType = 'creature';
+        result.affectsCount = null;
+    } else if (/\beach\s+creature\b/i.test(desc)) {
+        result.affectsType = 'creature';
+        result.affectsCount = null;
+    } else if (/\ballied\s+creature\b/i.test(desc) || /\ban?\s+ally\b/i.test(desc)) {
+        result.affectsType = 'ally';
+        result.affectsCount = 1;
+    } else if (/\b(?:one|a|an)\s+(?:\w+\s+)*?(?:creature|target)\b/i.test(desc)) {
+        result.affectsType = 'creature';
+        result.affectsCount = 1;
+    }
+
+    return result;
+}

--- a/src/statblock/adapters/dnd5e/actionParser.test.js
+++ b/src/statblock/adapters/dnd5e/actionParser.test.js
@@ -1,0 +1,408 @@
+import { parseAttackAction, parseSaveAction, parseRecharge, parseTargeting, parseDamageFromDescription, parseReactionTrigger, isMultiattack, extractWeaponName } from './actionParser.js';
+
+describe('actionParser', () => {
+    describe('parseAttackAction', () => {
+        it('returns non-attack for empty description', () => {
+            const result = parseAttackAction('');
+            expect(result.isAttack).toBe(false);
+        });
+
+        it('returns non-attack for non-attack description', () => {
+            const result = parseAttackAction('The creature takes the Disengage or Hide action.');
+            expect(result.isAttack).toBe(false);
+        });
+
+        it('parses melee weapon attack', () => {
+            const desc = '_Melee Weapon Attack:_ +5 to hit, reach 10 ft., one target. _Hit:_ 10 (2d6 + 3) piercing damage.';
+            const result = parseAttackAction(desc);
+
+            expect(result.isAttack).toBe(true);
+            expect(result.isMelee).toBe(true);
+            expect(result.isRanged).toBe(false);
+            expect(result.isWeapon).toBe(true);
+            expect(result.attackBonus).toBe(5);
+            expect(result.reach).toBe(10);
+            expect(result.damageFormula).toBe('2d6+3');
+            expect(result.damageType).toBe('piercing');
+        });
+
+        it('parses ranged weapon attack', () => {
+            const desc = '_Ranged Weapon Attack:_ +7 to hit, range 15/30., one target. _Hit:_ 11 (2d6 + 4) bludgeoning damage.';
+            const result = parseAttackAction(desc);
+
+            expect(result.isAttack).toBe(true);
+            expect(result.isMelee).toBe(false);
+            expect(result.isRanged).toBe(true);
+            expect(result.isWeapon).toBe(true);
+            expect(result.attackBonus).toBe(7);
+            expect(result.range).toBe(15);
+            expect(result.longRange).toBe(30);
+            expect(result.damageFormula).toBe('2d6+4');
+            expect(result.damageType).toBe('bludgeoning');
+        });
+
+        it('parses melee or ranged weapon attack', () => {
+            const desc = '_Melee or Ranged Weapon Attack:_ +5 to hit, reach 10 ft. or range 30/120 ft., one target. _Hit:_ 10 (2d6 + 3) piercing damage.';
+            const result = parseAttackAction(desc);
+
+            expect(result.isAttack).toBe(true);
+            expect(result.isMelee).toBe(true);
+            expect(result.isRanged).toBe(true);
+            expect(result.isWeapon).toBe(true);
+            expect(result.attackBonus).toBe(5);
+            expect(result.reach).toBe(10);
+            expect(result.range).toBe(30);
+            expect(result.longRange).toBe(120);
+        });
+
+        it('parses melee attack without "Weapon" keyword', () => {
+            const desc = '_Melee Attack:_ +6, reach 5 ft. _Hit:_ 16 (3d8 + 3) force damage.';
+            const result = parseAttackAction(desc);
+
+            expect(result.isAttack).toBe(true);
+            expect(result.isMelee).toBe(true);
+            expect(result.isWeapon).toBe(false);
+            expect(result.attackBonus).toBe(6);
+            expect(result.damageType).toBe('force');
+        });
+
+        it('parses attack roll variant', () => {
+            const desc = '_Melee or Ranged Attack Roll:_ +11 to hit, reach 5 ft. or range 120 ft. _Hit:_ 25 (4d8 + 7) force damage.';
+            const result = parseAttackAction(desc);
+
+            expect(result.isAttack).toBe(true);
+            expect(result.isMelee).toBe(true);
+            expect(result.isRanged).toBe(true);
+            expect(result.attackBonus).toBe(11);
+        });
+    });
+
+    describe('isMultiattack', () => {
+        it('returns true for Multiattack action', () => {
+            expect(isMultiattack({ name: 'Multiattack' })).toBe(true);
+            expect(isMultiattack({ name: 'Multiattack (Recharge 5-6)' })).toBe(true);
+        });
+
+        it('returns false for non-multiattack actions', () => {
+            expect(isMultiattack({ name: 'Longsword' })).toBe(false);
+            expect(isMultiattack({ name: 'Bite' })).toBe(false);
+        });
+
+        it('returns false for null/undefined', () => {
+            expect(isMultiattack(null)).toBe(false);
+            expect(isMultiattack(undefined)).toBe(false);
+            expect(isMultiattack({})).toBe(false);
+        });
+    });
+
+    describe('extractWeaponName', () => {
+        it('extracts simple weapon name', () => {
+            expect(extractWeaponName('Longsword')).toBe('Longsword');
+            expect(extractWeaponName('Javelin')).toBe('Javelin');
+        });
+
+        it('removes parenthetical notes', () => {
+            expect(extractWeaponName('Javelin (3)')).toBe('Javelin');
+            expect(extractWeaponName('Morningstar (Recharge 5-6)')).toBe('Morningstar');
+        });
+
+        it('handles empty input', () => {
+            expect(extractWeaponName('')).toBe('');
+            expect(extractWeaponName(null)).toBe('');
+        });
+    });
+
+    describe('parseSaveAction', () => {
+        it('returns non-save for empty description', () => {
+            const result = parseSaveAction('');
+            expect(result.isSave).toBe(false);
+        });
+
+        it('returns non-save for non-save description', () => {
+            const result = parseSaveAction('The creature teleports up to 30 feet.');
+            expect(result.isSave).toBe(false);
+        });
+
+        it('parses Fantasy Statblocks save format', () => {
+            const desc = '_Dexterity Saving Throw:_ DC 16, one medium or smaller creature. _Failure:_ The target is Grappled.';
+            const result = parseSaveAction(desc);
+
+            expect(result.isSave).toBe(true);
+            expect(result.ability).toBe('dex');
+            expect(result.dc).toBe(16);
+        });
+
+        it('parses DC-first save format', () => {
+            const desc = 'The target must make a DC 15 Constitution saving throw or be poisoned.';
+            const result = parseSaveAction(desc);
+
+            expect(result.isSave).toBe(true);
+            expect(result.ability).toBe('con');
+            expect(result.dc).toBe(15);
+        });
+
+        it('parses parenthetical DC format', () => {
+            const desc = 'Each creature must succeed on a Wisdom saving throw (DC 14) or be frightened.';
+            const result = parseSaveAction(desc);
+
+            expect(result.isSave).toBe(true);
+            expect(result.ability).toBe('wis');
+            expect(result.dc).toBe(14);
+        });
+
+        it('parses abbreviated save format', () => {
+            const desc = 'A creature can make a DC 12 Strength save to end the effect.';
+            const result = parseSaveAction(desc);
+
+            expect(result.isSave).toBe(true);
+            expect(result.ability).toBe('str');
+            expect(result.dc).toBe(12);
+        });
+    });
+
+    describe('parseRecharge', () => {
+        it('returns no recharge for regular name', () => {
+            const result = parseRecharge('Longsword');
+            expect(result.hasRecharge).toBe(false);
+            expect(result.cleanName).toBe('Longsword');
+        });
+
+        it('parses Recharge 5-6', () => {
+            const result = parseRecharge('Breath Weapon (Recharge 5-6)');
+            expect(result.hasRecharge).toBe(true);
+            expect(result.rechargeValue).toBe(5);
+            expect(result.cleanName).toBe('Breath Weapon');
+        });
+
+        it('parses Recharge 6', () => {
+            const result = parseRecharge('Elemental Summons (Recharge 6)');
+            expect(result.hasRecharge).toBe(true);
+            expect(result.rechargeValue).toBe(6);
+            expect(result.cleanName).toBe('Elemental Summons');
+        });
+
+        it('parses Recharge 4-6', () => {
+            const result = parseRecharge('Fire Breath (Recharge 4-6)');
+            expect(result.hasRecharge).toBe(true);
+            expect(result.rechargeValue).toBe(4);
+            expect(result.cleanName).toBe('Fire Breath');
+        });
+
+        it('handles empty input', () => {
+            const result = parseRecharge('');
+            expect(result.hasRecharge).toBe(false);
+            expect(result.cleanName).toBe('');
+        });
+
+        it('handles null input', () => {
+            const result = parseRecharge(null);
+            expect(result.hasRecharge).toBe(false);
+            expect(result.cleanName).toBe('');
+        });
+
+        it('parses 3/Day', () => {
+            const result = parseRecharge('Protective Magic (3/Day)');
+            expect(result.hasRecharge).toBe(false);
+            expect(result.hasUses).toBe(true);
+            expect(result.usesValue).toBe(3);
+            expect(result.usesPeriod).toBe('day');
+            expect(result.cleanName).toBe('Protective Magic');
+        });
+
+        it('parses 1/Day', () => {
+            const result = parseRecharge('Innate Spellcasting (1/Day)');
+            expect(result.hasUses).toBe(true);
+            expect(result.usesValue).toBe(1);
+            expect(result.usesPeriod).toBe('day');
+            expect(result.cleanName).toBe('Innate Spellcasting');
+        });
+
+        it('parses 1/Short Rest', () => {
+            const result = parseRecharge('Second Wind (1/Short Rest)');
+            expect(result.hasUses).toBe(true);
+            expect(result.usesValue).toBe(1);
+            expect(result.usesPeriod).toBe('sr');
+            expect(result.cleanName).toBe('Second Wind');
+        });
+
+        it('parses 1/Long Rest', () => {
+            const result = parseRecharge('Divine Intervention (1/Long Rest)');
+            expect(result.hasUses).toBe(true);
+            expect(result.usesValue).toBe(1);
+            expect(result.usesPeriod).toBe('lr');
+            expect(result.cleanName).toBe('Divine Intervention');
+        });
+
+        it('parses 3/Day Each variant', () => {
+            const result = parseRecharge('Spellcasting (3/Day Each)');
+            expect(result.hasUses).toBe(true);
+            expect(result.usesValue).toBe(3);
+            expect(result.usesPeriod).toBe('day');
+            expect(result.cleanName).toBe('Spellcasting');
+        });
+    });
+
+    describe('parseTargeting', () => {
+        it('returns empty result for null/empty', () => {
+            expect(parseTargeting(null).areaType).toBeNull();
+            expect(parseTargeting('').areaType).toBeNull();
+        });
+
+        it('parses 30-foot emanation', () => {
+            const desc = '_Constitution Saving Throw_ DC 18, all hostile creatures in a 30-foot emanation of the Bugbear.';
+            const result = parseTargeting(desc);
+
+            expect(result.areaType).toBe('radius');
+            expect(result.areaSize).toBe(30);
+            expect(result.affectsType).toBe('enemy');
+        });
+
+        it('parses 15-foot cone', () => {
+            const desc = 'Each creature in a 15-foot cone must make a Dexterity save.';
+            const result = parseTargeting(desc);
+
+            expect(result.areaType).toBe('cone');
+            expect(result.areaSize).toBe(15);
+        });
+
+        it('parses 20-foot-radius sphere', () => {
+            const desc = 'All creatures in a 20-foot-radius sphere must make a save.';
+            const result = parseTargeting(desc);
+
+            expect(result.areaType).toBe('sphere');
+            expect(result.areaSize).toBe(20);
+        });
+
+        it('parses within range', () => {
+            const desc = 'An allied creature the bugbear can see within 30 feet may use their reaction.';
+            const result = parseTargeting(desc);
+
+            expect(result.range).toBe(30);
+            expect(result.affectsType).toBe('ally');
+            expect(result.affectsCount).toBe(1);
+        });
+
+        it('parses between range', () => {
+            const desc = '_Dexterity Saving Throw:_ DC 17, a creature between 50 and 500 feet away.';
+            const result = parseTargeting(desc);
+
+            expect(result.range).toBe(50);
+            expect(result.longRange).toBe(500);
+            expect(result.affectsType).toBe('creature');
+            expect(result.affectsCount).toBe(1);
+        });
+
+        it('parses one creature target', () => {
+            const desc = '_Dexterity Saving Throw:_ DC 16, one medium or smaller creature.';
+            const result = parseTargeting(desc);
+
+            expect(result.affectsType).toBe('creature');
+            expect(result.affectsCount).toBe(1);
+        });
+
+        it('parses all creatures target', () => {
+            const desc = 'All creatures within 10 feet must make a save.';
+            const result = parseTargeting(desc);
+
+            expect(result.affectsType).toBe('creature');
+            expect(result.affectsCount).toBeNull();
+        });
+
+        it('parses each creature target', () => {
+            const desc = 'Each creature in the area takes damage.';
+            const result = parseTargeting(desc);
+
+            expect(result.affectsType).toBe('creature');
+            expect(result.affectsCount).toBeNull();
+        });
+    });
+
+    describe('parseReactionTrigger', () => {
+        it('returns no trigger for empty input', () => {
+            expect(parseReactionTrigger(null).hasTrigger).toBe(false);
+            expect(parseReactionTrigger('').hasTrigger).toBe(false);
+        });
+
+        it('returns no trigger for non-trigger description', () => {
+            const desc = 'The creature can make an opportunity attack.';
+            const result = parseReactionTrigger(desc);
+            expect(result.hasTrigger).toBe(false);
+        });
+
+        it('parses trigger and response from Parry', () => {
+            const desc = '_Trigger:_ The goblin is hit by a melee attack roll while holding a weapon. _Response:_ The goblin adds 3 to its AC against that attack.';
+            const result = parseReactionTrigger(desc);
+
+            expect(result.hasTrigger).toBe(true);
+            expect(result.trigger).toBe('The goblin is hit by a melee attack roll while holding a weapon.');
+            expect(result.response).toBe('The goblin adds 3 to its AC against that attack.');
+        });
+
+        it('parses trigger with save in response', () => {
+            const desc = '_Trigger:_ A creature the goblin can see hits it with an attack roll. _Response:_ Wisdom Saving Throw DC 13, the triggering creature. Failure, the attack misses instead.';
+            const result = parseReactionTrigger(desc);
+
+            expect(result.hasTrigger).toBe(true);
+            expect(result.trigger).toBe('A creature the goblin can see hits it with an attack roll.');
+            expect(result.response).toContain('Wisdom Saving Throw DC 13');
+        });
+
+        it('handles multiline response', () => {
+            const desc = '_Trigger:_ A creature hits the goblin. _Response:_ The goblin takes half damage and the attacker takes the other half.';
+            const result = parseReactionTrigger(desc);
+
+            expect(result.hasTrigger).toBe(true);
+            expect(result.response).toBe('The goblin takes half damage and the attacker takes the other half.');
+        });
+    });
+
+    describe('parseDamageFromDescription', () => {
+        it('returns no damage for empty input', () => {
+            expect(parseDamageFromDescription(null).hasDamage).toBe(false);
+            expect(parseDamageFromDescription('').hasDamage).toBe(false);
+        });
+
+        it('parses parenthetical damage format', () => {
+            const desc = 'The goblin deals an additional 2 (1d4) damage when it hits an attack with advantage.';
+            const result = parseDamageFromDescription(desc);
+
+            expect(result.hasDamage).toBe(true);
+            expect(result.formula).toBe('1d4');
+            expect(result.type).toBeNull();
+        });
+
+        it('parses damage with type', () => {
+            const desc = 'The creature deals 3 (1d6) fire damage on a hit.';
+            const result = parseDamageFromDescription(desc);
+
+            expect(result.hasDamage).toBe(true);
+            expect(result.formula).toBe('1d6');
+            expect(result.type).toBe('fire');
+        });
+
+        it('parses simple dice damage', () => {
+            const desc = 'Deals 2d6 radiant damage.';
+            const result = parseDamageFromDescription(desc);
+
+            expect(result.hasDamage).toBe(true);
+            expect(result.formula).toBe('2d6');
+            expect(result.type).toBe('radiant');
+        });
+
+        it('parses damage with bonus', () => {
+            const desc = 'Takes 4 (1d6 + 1) poison damage.';
+            const result = parseDamageFromDescription(desc);
+
+            expect(result.hasDamage).toBe(true);
+            expect(result.formula).toBe('1d6+1');
+            expect(result.type).toBe('poison');
+        });
+
+        it('returns no damage for non-damage text', () => {
+            const desc = 'The creature has advantage on saving throws.';
+            const result = parseDamageFromDescription(desc);
+
+            expect(result.hasDamage).toBe(false);
+        });
+    });
+});

--- a/src/statblock/adapters/dnd5e/compendiumLookup.js
+++ b/src/statblock/adapters/dnd5e/compendiumLookup.js
@@ -1,0 +1,207 @@
+/**
+ * Compendium lookup utilities for dnd5e items and spells.
+ * Searches SRD compendiums for matching items.
+ */
+
+/**
+ * Cache for compendium indexes to avoid repeated lookups.
+ * @type {Map<string, Map<string, Object>>}
+ */
+const indexCache = new Map();
+
+/**
+ * Gets or builds an index for a compendium, keyed by lowercase name.
+ *
+ * @param {string} packId - Compendium pack ID (e.g., "dnd5e.items")
+ * @returns {Promise<Map<string, Object>>} Map of lowercase name -> index entry
+ */
+async function getCompendiumIndex(packId) {
+    if (indexCache.has(packId)) {
+        return indexCache.get(packId);
+    }
+
+    const pack = game.packs.get(packId);
+    if (!pack) {
+        const emptyMap = new Map();
+        indexCache.set(packId, emptyMap);
+        return emptyMap;
+    }
+
+    const index = await pack.getIndex();
+    const nameMap = new Map();
+
+    for (const entry of index) {
+        const lowerName = entry.name.toLowerCase();
+        // Store first match only (avoid duplicates)
+        if (!nameMap.has(lowerName)) {
+            nameMap.set(lowerName, { ...entry, packId });
+        }
+    }
+
+    indexCache.set(packId, nameMap);
+    return nameMap;
+}
+
+/**
+ * Clears the compendium index cache.
+ * Call this if compendiums are modified.
+ */
+export function clearCompendiumCache() {
+    indexCache.clear();
+}
+
+/**
+ * Searches for an item in the dnd5e items compendium.
+ *
+ * @param {string} name - Item name to search for
+ * @returns {Promise<Object|null>} Full item document or null if not found
+ */
+export async function findItem(name) {
+    if (!name) {
+        return null;
+    }
+
+    const lowerName = name.toLowerCase().trim();
+
+    // Try dnd5e.items first (SRD items)
+    const itemsIndex = await getCompendiumIndex('dnd5e.items');
+    let entry = itemsIndex.get(lowerName);
+
+    // Try dnd5e.equipment if not found
+    if (!entry) {
+        const equipIndex = await getCompendiumIndex('dnd5e.equipment');
+        entry = equipIndex.get(lowerName);
+    }
+
+    if (!entry) {
+        return null;
+    }
+
+    // Load full document
+    const pack = game.packs.get(entry.packId);
+    if (!pack) {
+        return null;
+    }
+
+    return pack.getDocument(entry._id);
+}
+
+/**
+ * Searches for a spell in the dnd5e spells compendium.
+ *
+ * @param {string} name - Spell name to search for
+ * @returns {Promise<Object|null>} Full spell document or null if not found
+ */
+export async function findSpell(name) {
+    if (!name) {
+        return null;
+    }
+
+    const lowerName = name.toLowerCase().trim();
+
+    // Try dnd5e.spells (SRD spells)
+    const spellsIndex = await getCompendiumIndex('dnd5e.spells');
+    const entry = spellsIndex.get(lowerName);
+
+    if (!entry) {
+        return null;
+    }
+
+    // Load full document
+    const pack = game.packs.get(entry.packId);
+    if (!pack) {
+        return null;
+    }
+
+    return pack.getDocument(entry._id);
+}
+
+/**
+ * Batch lookup for multiple spells.
+ * More efficient than individual lookups.
+ *
+ * @param {string[]} names - Array of spell names
+ * @returns {Promise<Map<string, Object>>} Map of lowercase name -> spell document
+ */
+export async function findSpells(names) {
+    const results = new Map();
+
+    if (!names || names.length === 0) {
+        return results;
+    }
+
+    const spellsIndex = await getCompendiumIndex('dnd5e.spells');
+    const pack = game.packs.get('dnd5e.spells');
+
+    if (!pack) {
+        return results;
+    }
+
+    // Collect all matching entries
+    const toLoad = [];
+    for (const name of names) {
+        const lowerName = name.toLowerCase().trim();
+        const entry = spellsIndex.get(lowerName);
+        if (entry && !results.has(lowerName)) {
+            toLoad.push({ name: lowerName, id: entry._id });
+        }
+    }
+
+    // Batch load documents
+    for (const { name, id } of toLoad) {
+        try {
+            const doc = await pack.getDocument(id);
+            if (doc) {
+                results.set(name, doc);
+            }
+        } catch (e) {
+            console.warn(`Failed to load spell "${name}":`, e);
+        }
+    }
+
+    return results;
+}
+
+/**
+ * Batch lookup for multiple items.
+ *
+ * @param {string[]} names - Array of item names
+ * @returns {Promise<Map<string, Object>>} Map of lowercase name -> item document
+ */
+export async function findItems(names) {
+    const results = new Map();
+
+    if (!names || names.length === 0) {
+        return results;
+    }
+
+    const itemsIndex = await getCompendiumIndex('dnd5e.items');
+    const equipIndex = await getCompendiumIndex('dnd5e.equipment');
+
+    // Collect all matching entries
+    const toLoad = [];
+    for (const name of names) {
+        const lowerName = name.toLowerCase().trim();
+        let entry = itemsIndex.get(lowerName) || equipIndex.get(lowerName);
+        if (entry && !results.has(lowerName)) {
+            toLoad.push({ name: lowerName, entry });
+        }
+    }
+
+    // Load documents
+    for (const { name, entry } of toLoad) {
+        try {
+            const pack = game.packs.get(entry.packId);
+            if (pack) {
+                const doc = await pack.getDocument(entry._id);
+                if (doc) {
+                    results.set(name, doc);
+                }
+            }
+        } catch (e) {
+            console.warn(`Failed to load item "${name}":`, e);
+        }
+    }
+
+    return results;
+}

--- a/src/statblock/adapters/dnd5e/compendiumLookup.js
+++ b/src/statblock/adapters/dnd5e/compendiumLookup.js
@@ -63,11 +63,9 @@ export async function findItem(name) {
 
     const lowerName = name.toLowerCase().trim();
 
-    // Try dnd5e.items first (SRD items)
     const itemsIndex = await getCompendiumIndex('dnd5e.items');
     let entry = itemsIndex.get(lowerName);
 
-    // Try dnd5e.equipment if not found
     if (!entry) {
         const equipIndex = await getCompendiumIndex('dnd5e.equipment');
         entry = equipIndex.get(lowerName);
@@ -77,7 +75,6 @@ export async function findItem(name) {
         return null;
     }
 
-    // Load full document
     const pack = game.packs.get(entry.packId);
     if (!pack) {
         return null;
@@ -99,7 +96,6 @@ export async function findSpell(name) {
 
     const lowerName = name.toLowerCase().trim();
 
-    // Try dnd5e.spells (SRD spells)
     const spellsIndex = await getCompendiumIndex('dnd5e.spells');
     const entry = spellsIndex.get(lowerName);
 
@@ -107,7 +103,6 @@ export async function findSpell(name) {
         return null;
     }
 
-    // Load full document
     const pack = game.packs.get(entry.packId);
     if (!pack) {
         return null;
@@ -137,7 +132,6 @@ export async function findSpells(names) {
         return results;
     }
 
-    // Collect all matching entries
     const toLoad = [];
     for (const name of names) {
         const lowerName = name.toLowerCase().trim();
@@ -147,7 +141,6 @@ export async function findSpells(names) {
         }
     }
 
-    // Batch load documents
     for (const { name, id } of toLoad) {
         try {
             const doc = await pack.getDocument(id);
@@ -178,7 +171,6 @@ export async function findItems(names) {
     const itemsIndex = await getCompendiumIndex('dnd5e.items');
     const equipIndex = await getCompendiumIndex('dnd5e.equipment');
 
-    // Collect all matching entries
     const toLoad = [];
     for (const name of names) {
         const lowerName = name.toLowerCase().trim();
@@ -188,7 +180,6 @@ export async function findItems(names) {
         }
     }
 
-    // Load documents
     for (const { name, entry } of toLoad) {
         try {
             const pack = game.packs.get(entry.packId);

--- a/src/statblock/adapters/dnd5e/gearParser.js
+++ b/src/statblock/adapters/dnd5e/gearParser.js
@@ -1,0 +1,93 @@
+/**
+ * Parses gear traits to extract equipment items.
+ *
+ * Expected format in traits:
+ * - name: Gear
+ *   desc: Chain Shirt, Javelin (3), Morningstar
+ */
+
+/**
+ * Parsed gear item.
+ * @typedef {Object} ParsedGear
+ * @property {string} name - Item name
+ * @property {number} quantity - Item quantity (default 1)
+ */
+
+/**
+ * Parses a gear description string into individual items.
+ *
+ * @param {string} desc - Gear description (e.g., "Chain Shirt, Javelin (3), Morningstar")
+ * @returns {ParsedGear[]} Array of parsed gear items
+ */
+export function parseGearDescription(desc) {
+    if (!desc || typeof desc !== 'string') {
+        return [];
+    }
+
+    const items = [];
+    const parts = desc.split(',').map(p => p.trim()).filter(p => p.length > 0);
+
+    for (const part of parts) {
+        // Check for quantity in parentheses: "Javelin (3)"
+        const quantityMatch = part.match(/^(.+?)\s*\((\d+)\)$/);
+
+        if (quantityMatch) {
+            items.push({
+                name: quantityMatch[1].trim(),
+                quantity: parseInt(quantityMatch[2], 10)
+            });
+        } else {
+            items.push({
+                name: part.trim(),
+                quantity: 1
+            });
+        }
+    }
+
+    return items;
+}
+
+/**
+ * Extracts gear from a statblock's traits.
+ * Looks for a trait named "Gear" or "Equipment".
+ *
+ * @param {Array} traits - Array of trait objects with name and desc
+ * @returns {ParsedGear[]} Array of parsed gear items
+ */
+export function extractGearFromTraits(traits) {
+    if (!traits || !Array.isArray(traits)) {
+        return [];
+    }
+
+    for (const trait of traits) {
+        if (!trait?.name) {
+            continue;
+        }
+
+        const name = trait.name.toLowerCase();
+        if (name === 'gear' || name === 'equipment') {
+            return parseGearDescription(trait.desc);
+        }
+    }
+
+    return [];
+}
+
+/**
+ * Normalizes an item name for compendium lookup.
+ * Handles common variations and formatting.
+ *
+ * @param {string} name - Item name from statblock
+ * @returns {string} Normalized name for lookup
+ */
+export function normalizeItemName(name) {
+    if (!name) {
+        return '';
+    }
+
+    return name
+        .toLowerCase()
+        .trim()
+        // Remove "of" articles for simplicity in matching
+        .replace(/\s+/g, ' ');
+}

--- a/src/statblock/adapters/dnd5e/gearParser.test.js
+++ b/src/statblock/adapters/dnd5e/gearParser.test.js
@@ -1,0 +1,94 @@
+import { parseGearDescription, extractGearFromTraits, normalizeItemName } from './gearParser.js';
+
+describe('gearParser', () => {
+    describe('parseGearDescription', () => {
+        it('returns empty array for null input', () => {
+            expect(parseGearDescription(null)).toEqual([]);
+            expect(parseGearDescription('')).toEqual([]);
+        });
+
+        it('parses single item', () => {
+            const result = parseGearDescription('Chain Shirt');
+            expect(result).toEqual([{ name: 'Chain Shirt', quantity: 1 }]);
+        });
+
+        it('parses multiple items', () => {
+            const result = parseGearDescription('Chain Shirt, Longsword, Shield');
+            expect(result).toEqual([
+                { name: 'Chain Shirt', quantity: 1 },
+                { name: 'Longsword', quantity: 1 },
+                { name: 'Shield', quantity: 1 }
+            ]);
+        });
+
+        it('parses items with quantities', () => {
+            const result = parseGearDescription('Chain Shirt, Javelin (3), Morningstar');
+            expect(result).toEqual([
+                { name: 'Chain Shirt', quantity: 1 },
+                { name: 'Javelin', quantity: 3 },
+                { name: 'Morningstar', quantity: 1 }
+            ]);
+        });
+
+        it('handles whitespace', () => {
+            const result = parseGearDescription('  Chain Shirt ,  Javelin (3) ,  Morningstar  ');
+            expect(result).toEqual([
+                { name: 'Chain Shirt', quantity: 1 },
+                { name: 'Javelin', quantity: 3 },
+                { name: 'Morningstar', quantity: 1 }
+            ]);
+        });
+    });
+
+    describe('extractGearFromTraits', () => {
+        it('returns empty array for null input', () => {
+            expect(extractGearFromTraits(null)).toEqual([]);
+            expect(extractGearFromTraits([])).toEqual([]);
+        });
+
+        it('extracts gear from Gear trait', () => {
+            const traits = [
+                { name: 'Abduct', desc: 'Some ability' },
+                { name: 'Gear', desc: 'Chain Shirt, Javelin (3), Morningstar' }
+            ];
+            const result = extractGearFromTraits(traits);
+            expect(result).toEqual([
+                { name: 'Chain Shirt', quantity: 1 },
+                { name: 'Javelin', quantity: 3 },
+                { name: 'Morningstar', quantity: 1 }
+            ]);
+        });
+
+        it('extracts gear from Equipment trait', () => {
+            const traits = [
+                { name: 'Equipment', desc: 'Leather Armor, Dagger' }
+            ];
+            const result = extractGearFromTraits(traits);
+            expect(result).toEqual([
+                { name: 'Leather Armor', quantity: 1 },
+                { name: 'Dagger', quantity: 1 }
+            ]);
+        });
+
+        it('returns empty array if no gear trait found', () => {
+            const traits = [
+                { name: 'Keen Senses', desc: 'Advantage on Perception' },
+                { name: 'Pack Tactics', desc: 'Advantage when ally nearby' }
+            ];
+            const result = extractGearFromTraits(traits);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('normalizeItemName', () => {
+        it('lowercases and trims', () => {
+            expect(normalizeItemName('  Chain Shirt  ')).toBe('chain shirt');
+            expect(normalizeItemName('LONGSWORD')).toBe('longsword');
+        });
+
+        it('handles empty input', () => {
+            expect(normalizeItemName('')).toBe('');
+            expect(normalizeItemName(null)).toBe('');
+        });
+    });
+});

--- a/src/statblock/adapters/dnd5e/index.js
+++ b/src/statblock/adapters/dnd5e/index.js
@@ -1,0 +1,123 @@
+/**
+ * dnd5e adapter for statblock import.
+ * Requires dnd5e system version 5.1 or higher.
+ */
+
+import StatblockAdapterRegistry from '../../registry.js';
+import { mapToDnd5eActor, createEmbeddedItemsAsync } from './mapper.js';
+import { id as MODULE_ID } from '../../../../module.json';
+
+/**
+ * Adapter for the dnd5e game system.
+ * Handles conversion of StatblockData to dnd5e Actor documents.
+ */
+const DND5E_ADAPTER = {
+    /**
+     * Checks if the current dnd5e system version is supported.
+     * Requires dnd5e 5.1+ for the current NPC schema.
+     *
+     * @returns {boolean} True if system is dnd5e 5.1+
+     */
+    isSupported() {
+        // Check if we're in a Foundry context with game.system available
+        if (typeof game === 'undefined' || !game.system?.id) {
+            return false;
+        }
+
+        if (game.system.id !== 'dnd5e') {
+            return false;
+        }
+
+        // Parse version - require 5.1+
+        const version = game.system.version;
+        if (!version) {
+            return false;
+        }
+
+        const parts = version.split('.').map(Number);
+        const major = parts[0] || 0;
+        const minor = parts[1] || 0;
+
+        return major > 5 || (major === 5 && minor >= 1);
+    },
+
+    /**
+     * Creates a new Actor from a StatblockData object.
+     *
+     * @param {StatblockData} statblock - Parsed statblock data
+     * @param {Object} options - Import options
+     * @param {Folder|null} options.folder - Target folder for the actor
+     * @returns {Promise<Actor>} The created Actor document
+     */
+    async createActor(statblock, options = {}) {
+        const actorData = mapToDnd5eActor(statblock);
+
+        // Set folder if provided
+        if (options.folder) {
+            actorData.folder = options.folder.id;
+        }
+
+        // Create the actor
+        const actor = await Actor.create(actorData);
+
+        // Create embedded items (traits, actions, spells, gear)
+        const items = await createEmbeddedItemsAsync(statblock);
+        if (items.length > 0) {
+            await actor.createEmbeddedDocuments('Item', items);
+        }
+
+        return actor;
+    },
+
+    /**
+     * Updates an existing Actor with new statblock data.
+     * Replaces actor system data and recreates all items that were
+     * originally imported from a statblock.
+     *
+     * @param {Actor} existing - The existing Actor document to update
+     * @param {StatblockData} statblock - New statblock data
+     * @returns {Promise<Actor>} The updated Actor document
+     */
+    async updateActor(existing, statblock) {
+        const actorData = mapToDnd5eActor(statblock);
+
+        // Update the actor's system data
+        // We need to be careful not to overwrite folder, permissions, etc.
+        await existing.update({
+            name: actorData.name,
+            img: actorData.img,
+            system: actorData.system,
+            flags: actorData.flags
+        });
+
+        // Delete old items that we created (flagged with fromStatblock)
+        const oldItems = existing.items.filter(item =>
+            item.flags[MODULE_ID]?.fromStatblock === true
+        );
+
+        if (oldItems.length > 0) {
+            await existing.deleteEmbeddedDocuments(
+                'Item',
+                oldItems.map(item => item.id)
+            );
+        }
+
+        // Create new items
+        const items = await createEmbeddedItemsAsync(statblock);
+        if (items.length > 0) {
+            await existing.createEmbeddedDocuments('Item', items);
+        }
+
+        return existing;
+    }
+};
+
+/**
+ * Registers the dnd5e adapter with the StatblockAdapterRegistry.
+ * This function should be called during module initialization.
+ */
+export function registerDnd5eAdapter() {
+    StatblockAdapterRegistry.register('dnd5e', DND5E_ADAPTER);
+}
+
+export default DND5E_ADAPTER;

--- a/src/statblock/adapters/dnd5e/index.js
+++ b/src/statblock/adapters/dnd5e/index.js
@@ -19,7 +19,6 @@ const DND5E_ADAPTER = {
      * @returns {boolean} True if system is dnd5e 5.1+
      */
     isSupported() {
-        // Check if we're in a Foundry context with game.system available
         if (typeof game === 'undefined' || !game.system?.id) {
             return false;
         }
@@ -28,7 +27,6 @@ const DND5E_ADAPTER = {
             return false;
         }
 
-        // Parse version - require 5.1+
         const version = game.system.version;
         if (!version) {
             return false;
@@ -52,15 +50,12 @@ const DND5E_ADAPTER = {
     async createActor(statblock, options = {}) {
         const actorData = mapToDnd5eActor(statblock);
 
-        // Set folder if provided
         if (options.folder) {
             actorData.folder = options.folder.id;
         }
 
-        // Create the actor
         const actor = await Actor.create(actorData);
 
-        // Create embedded items (traits, actions, spells, gear)
         const items = await createEmbeddedItemsAsync(statblock);
         if (items.length > 0) {
             await actor.createEmbeddedDocuments('Item', items);
@@ -81,8 +76,6 @@ const DND5E_ADAPTER = {
     async updateActor(existing, statblock) {
         const actorData = mapToDnd5eActor(statblock);
 
-        // Update the actor's system data
-        // We need to be careful not to overwrite folder, permissions, etc.
         await existing.update({
             name: actorData.name,
             img: actorData.img,
@@ -90,7 +83,6 @@ const DND5E_ADAPTER = {
             flags: actorData.flags
         });
 
-        // Delete old items that we created (flagged with fromStatblock)
         const oldItems = existing.items.filter(item =>
             item.flags[MODULE_ID]?.fromStatblock === true
         );
@@ -102,7 +94,6 @@ const DND5E_ADAPTER = {
             );
         }
 
-        // Create new items
         const items = await createEmbeddedItemsAsync(statblock);
         if (items.length > 0) {
             await existing.createEmbeddedDocuments('Item', items);

--- a/src/statblock/adapters/dnd5e/mapper.js
+++ b/src/statblock/adapters/dnd5e/mapper.js
@@ -1,0 +1,1065 @@
+/**
+ * Maps StatblockData to dnd5e 5.1+ Actor and Item data structures.
+ * Reference: dnd5e/module/data/actor/npc.mjs and related schemas.
+ */
+
+import { id as MODULE_ID } from '../../../../module.json';
+import { parseAttackAction, parseSaveAction, parseRecharge, parseTargeting, parseDamageFromDescription, parseReactionTrigger, isMultiattack, extractWeaponName } from './actionParser.js';
+import { parseSpellcasting, parseSpellcastingTrait } from './spellcastingParser.js';
+import { extractGearFromTraits, normalizeItemName } from './gearParser.js';
+import { findItems, findSpells } from './compendiumLookup.js';
+
+const VALID_SIZES = new Set(['tiny', 'sm', 'med', 'lg', 'huge', 'grg']);
+
+const CREATURE_TYPES = new Set([
+    'aberration', 'beast', 'celestial', 'construct', 'dragon',
+    'elemental', 'fey', 'fiend', 'giant', 'humanoid', 'monstrosity',
+    'ooze', 'plant', 'undead'
+]);
+
+const DAMAGE_TYPES = new Set([
+    'acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning',
+    'necrotic', 'piercing', 'poison', 'psychic', 'radiant', 'slashing', 'thunder'
+]);
+
+const CONDITIONS = new Set([
+    'blinded', 'charmed', 'deafened', 'exhaustion', 'frightened',
+    'grappled', 'incapacitated', 'invisible', 'paralyzed', 'petrified',
+    'poisoned', 'prone', 'restrained', 'stunned', 'unconscious'
+]);
+
+const SENSES = new Set(['blindsight', 'darkvision', 'tremorsense', 'truesight']);
+
+const SKILL_MAP = {
+    acrobatics: 'acr',
+    animalhandling: 'ani',
+    'animal handling': 'ani',
+    arcana: 'arc',
+    athletics: 'ath',
+    deception: 'dec',
+    history: 'his',
+    insight: 'ins',
+    intimidation: 'itm',
+    investigation: 'inv',
+    medicine: 'med',
+    nature: 'nat',
+    perception: 'prc',
+    performance: 'prf',
+    persuasion: 'per',
+    religion: 'rel',
+    sleightofhand: 'slt',
+    'sleight of hand': 'slt',
+    stealth: 'ste',
+    survival: 'sur'
+};
+
+const SKILL_ABILITIES = {
+    acr: 'dex', ani: 'wis', arc: 'int', ath: 'str', dec: 'cha',
+    his: 'int', ins: 'wis', itm: 'cha', inv: 'int', med: 'wis',
+    nat: 'int', prc: 'wis', prf: 'cha', per: 'cha', rel: 'int',
+    slt: 'dex', ste: 'dex', sur: 'wis'
+};
+
+const MOVEMENT_TYPES = new Set(['walk', 'burrow', 'climb', 'fly', 'swim']);
+
+const KNOWN_LANGUAGES = new Set([
+    'common', 'dwarvish', 'elvish', 'giant', 'gnomish', 'goblin',
+    'halfling', 'orc', 'abyssal', 'celestial', 'draconic', 'deep',
+    'infernal', 'primordial', 'sylvan', 'undercommon', 'druidic',
+    'thieves', 'telepathy'
+]);
+
+const ACTIVATION_ICONS = {
+    action: 'systems/dnd5e/icons/svg/activity/attack.svg',
+    bonus: 'systems/dnd5e/icons/svg/activity/utility.svg',
+    reaction: 'systems/dnd5e/icons/svg/activity/save.svg',
+    legendary: 'systems/dnd5e/icons/svg/activity/damage.svg',
+    trait: 'icons/svg/book.svg'
+};
+
+/**
+ * Converts simple markdown formatting to HTML.
+ *
+ * @param {string} text - Markdown text
+ * @returns {string} HTML text
+ */
+function markdownToHtml(text) {
+    if (!text) {
+        return '';
+    }
+
+    let html = text
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/__([^_]+)__/g, '<strong>$1</strong>')
+        .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+        .replace(/_([^_]+)_/g, '<em>$1</em>')
+        .replace(/\n\n+/g, '</p><p>')
+        .replace(/\n/g, '<br>');
+
+    if (!html.startsWith('<p>')) {
+        html = '<p>' + html + '</p>';
+    }
+
+    return html;
+}
+
+/**
+ * Normalizes a string to a valid dnd5e key format.
+ *
+ * @param {string} str - String to normalize
+ * @returns {string} Lowercase, trimmed string
+ */
+function normalizeKey(str) {
+    if (!str) {
+        return '';
+    }
+    return String(str).toLowerCase().trim();
+}
+
+/**
+ * Maps a creature type string to dnd5e creature type object.
+ *
+ * @param {string} type - Creature type string
+ * @param {string} subtype - Optional subtype
+ * @returns {Object} dnd5e creature type object
+ */
+function mapCreatureType(type, subtype) {
+    const normalized = normalizeKey(type);
+    const typeValue = CREATURE_TYPES.has(normalized) ? normalized : 'custom';
+
+    return {
+        value: typeValue,
+        subtype: subtype || '',
+        swarm: '',
+        custom: typeValue === 'custom' ? type : ''
+    };
+}
+
+/**
+ * Maps ability scores and saving throw proficiencies to dnd5e format.
+ *
+ * @param {Object} abilities - Ability scores {str: 10, dex: 15, ...}
+ * @param {Object|null} savingThrows - Saving throw bonuses {str: 5, con: 7, ...}
+ * @returns {Object} dnd5e abilities object
+ */
+function mapAbilities(abilities, savingThrows) {
+    const result = {};
+    const abilityKeys = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+
+    for (const key of abilityKeys) {
+        const score = abilities?.[key] ?? 10;
+        const mod = Math.floor((score - 10) / 2);
+
+        let proficient = 0;
+        if (savingThrows && savingThrows[key] !== undefined) {
+            const saveBonus = savingThrows[key];
+            if (saveBonus > mod) {
+                proficient = 1;
+            }
+        }
+
+        result[key] = {
+            value: score,
+            proficient,
+            bonuses: {
+                check: '',
+                save: ''
+            }
+        };
+    }
+
+    return result;
+}
+
+/**
+ * Maps movement speeds to dnd5e movement object.
+ *
+ * @param {Object|null} speed - Speed object {walk: 30, fly: 60, ...}
+ * @returns {Object} dnd5e movement object
+ */
+function mapMovement(speed) {
+    const movement = {
+        burrow: 0,
+        climb: 0,
+        fly: 0,
+        swim: 0,
+        walk: 0,
+        units: 'ft',
+        hover: false
+    };
+
+    if (!speed) {
+        return movement;
+    }
+
+    for (const [key, value] of Object.entries(speed)) {
+        const normalized = normalizeKey(key);
+        if (MOVEMENT_TYPES.has(normalized) && typeof value === 'number') {
+            movement[normalized] = value;
+        }
+        if (normalized === 'hover') {
+            movement.hover = true;
+        }
+    }
+
+    return movement;
+}
+
+/**
+ * Maps senses to dnd5e senses object.
+ *
+ * @param {Object|null} senses - Senses object {darkvision: 60, passivePerception: 15, ...}
+ * @returns {Object} dnd5e senses object
+ */
+function mapSenses(senses) {
+    const result = {
+        blindsight: 0,
+        darkvision: 0,
+        tremorsense: 0,
+        truesight: 0,
+        units: 'ft',
+        special: ''
+    };
+
+    if (!senses) {
+        return result;
+    }
+
+    for (const [key, value] of Object.entries(senses)) {
+        const normalized = normalizeKey(key);
+        if (SENSES.has(normalized) && typeof value === 'number') {
+            result[normalized] = value;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Maps skills to dnd5e skill proficiency format.
+ *
+ * @param {Object|null} skills - Skills object {stealth: 6, perception: 4, ...}
+ * @param {Object} abilities - Ability scores for calculating modifiers
+ * @param {number} profBonus - Calculated proficiency bonus
+ * @returns {Object} dnd5e skills object with proficiency values
+ */
+function mapSkills(skills, abilities, profBonus) {
+    const result = {};
+
+    if (!skills) {
+        return result;
+    }
+
+    for (const [skillName, bonus] of Object.entries(skills)) {
+        const normalized = normalizeKey(skillName).replace(/\s+/g, '');
+        const skillKey = SKILL_MAP[normalized] || SKILL_MAP[skillName.toLowerCase()];
+
+        if (!skillKey) {
+            continue;
+        }
+
+        const abilityKey = SKILL_ABILITIES[skillKey];
+        const abilityScore = abilities?.[abilityKey] ?? 10;
+        const abilityMod = Math.floor((abilityScore - 10) / 2);
+        const difference = bonus - abilityMod;
+        let profValue = 0;
+
+        if (profBonus > 0) {
+            if (difference >= profBonus * 2) {
+                profValue = 2;
+            } else if (difference >= profBonus) {
+                profValue = 1;
+            } else if (difference > 0) {
+                profValue = 0.5;
+            }
+        }
+
+        result[skillKey] = {
+            value: profValue
+        };
+    }
+
+    return result;
+}
+
+/**
+ * Maps a list of damage type strings to dnd5e damage type keys.
+ *
+ * @param {string[]|null} types - Array of damage type strings
+ * @returns {string[]} Array of valid dnd5e damage type keys
+ */
+function mapDamageTypes(types) {
+    if (!types || !Array.isArray(types)) {
+        return [];
+    }
+
+    const result = [];
+    for (const type of types) {
+        const normalized = normalizeKey(type);
+        if (DAMAGE_TYPES.has(normalized)) {
+            result.push(normalized);
+        }
+    }
+    return result;
+}
+
+/**
+ * Maps a list of condition strings to dnd5e condition keys.
+ *
+ * @param {string[]|null} conditions - Array of condition strings
+ * @returns {string[]} Array of valid dnd5e condition keys
+ */
+function mapConditions(conditions) {
+    if (!conditions || !Array.isArray(conditions)) {
+        return [];
+    }
+
+    const result = [];
+    for (const condition of conditions) {
+        const normalized = normalizeKey(condition);
+        if (CONDITIONS.has(normalized)) {
+            result.push(normalized);
+        }
+    }
+    return result;
+}
+
+/**
+ * Maps languages array, handling both standard and custom languages.
+ *
+ * @param {string[]|null} languages - Array of language strings
+ * @returns {Object} Object with value Set and custom string
+ */
+function mapLanguages(languages) {
+    if (!languages || !Array.isArray(languages)) {
+        return {
+            value: new Set(),
+            custom: ''
+        };
+    }
+
+    const value = new Set();
+    const custom = [];
+
+    for (const lang of languages) {
+        const normalized = normalizeKey(lang);
+        if (KNOWN_LANGUAGES.has(normalized)) {
+            value.add(normalized);
+        } else {
+            custom.push(lang);
+        }
+    }
+
+    return {
+        value,
+        custom: custom.join('; ')
+    };
+}
+
+/**
+ * Calculates proficiency bonus from CR using standard 5e formula.
+ *
+ * @param {number|null} cr - Challenge rating
+ * @returns {number} Proficiency bonus
+ */
+function calculateProfBonus(cr) {
+    if (cr === null || cr === undefined || cr < 1) {
+        return 2;
+    }
+    return Math.floor((cr - 1) / 4) + 2;
+}
+
+/**
+ * Extracts legendary resistance count from traits.
+ *
+ * @param {Array|null} traits - Array of trait objects with name and desc
+ * @returns {number} Number of legendary resistances (0 if none found)
+ */
+function extractLegendaryResistances(traits) {
+    if (!traits || !Array.isArray(traits)) {
+        return 0;
+    }
+
+    for (const trait of traits) {
+        if (!trait?.name) {
+            continue;
+        }
+        const match = trait.name.match(/^Legendary Resistances?\s*\((\d+)\/Day\)/i);
+        if (match) {
+            return parseInt(match[1], 10);
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Maps a StatblockData object to dnd5e Actor.create() data.
+ *
+ * @param {StatblockData} statblock - Parsed statblock data
+ * @returns {Object} Data object suitable for Actor.create()
+ */
+export function mapToDnd5eActor(statblock) {
+    const profBonus = calculateProfBonus(statblock.cr);
+    const abilities = mapAbilities(statblock.abilities, statblock.savingThrows);
+    const size = VALID_SIZES.has(statblock.size) ? statblock.size : 'med';
+
+    return {
+        name: statblock.name || 'Unknown Creature',
+        type: 'npc',
+        img: 'icons/svg/mystery-man.svg',
+
+        flags: {
+            [MODULE_ID]: {
+                sourceFile: statblock.filePath,
+                importedAt: Date.now()
+            }
+        },
+
+        system: {
+            abilities,
+            attributes: {
+                ac: {
+                    flat: statblock.ac ?? 10,
+                    calc: 'flat'
+                },
+                hp: {
+                    value: statblock.hp ?? 1,
+                    max: statblock.hp ?? 1,
+                    formula: statblock.hitDice || ''
+                },
+                movement: mapMovement(statblock.speed),
+                senses: mapSenses(statblock.senses)
+            },
+            details: {
+                type: mapCreatureType(statblock.type, statblock.subtype),
+                alignment: statblock.alignment || '',
+                cr: statblock.cr,
+                biography: {
+                    value: ''
+                }
+            },
+            traits: {
+                size,
+                languages: mapLanguages(statblock.languages),
+                di: {
+                    value: new Set(mapDamageTypes(statblock.damageImmunities)),
+                    custom: ''
+                },
+                dr: {
+                    value: new Set(mapDamageTypes(statblock.damageResistances)),
+                    custom: ''
+                },
+                dv: {
+                    value: new Set(mapDamageTypes(statblock.damageVulnerabilities)),
+                    custom: ''
+                },
+                ci: {
+                    value: new Set(mapConditions(statblock.conditionImmunities)),
+                    custom: ''
+                }
+            },
+            resources: {
+                legact: {
+                    max: (statblock.legendaryActions?.length > 0) ? 3 : 0,
+                    spent: 0
+                },
+                legres: {
+                    max: extractLegendaryResistances(statblock.traits),
+                    spent: 0
+                }
+            },
+            skills: mapSkills(statblock.skills, statblock.abilities, profBonus)
+        }
+    };
+}
+
+/**
+ * Creates a feat item for non-attack actions and traits.
+ *
+ * @param {Object} action - Action object with name and desc
+ * @param {string|null} activationType - Activation type (null for traits)
+ * @param {string} filePath - Source file path for tracking
+ * @returns {Object} Feat item data
+ */
+function createFeatItem(action, activationType, filePath, attackData = null) {
+    if (!action?.name) {
+        return null;
+    }
+
+    const rechargeInfo = parseRecharge(action.name);
+    const reactionInfo = activationType === 'reaction' ? parseReactionTrigger(action.desc) : null;
+    const activationCondition = reactionInfo?.hasTrigger ? reactionInfo.trigger : '';
+
+    const iconKey = activationType || 'trait';
+    const item = {
+        name: rechargeInfo.cleanName,
+        type: 'feat',
+        img: ACTIVATION_ICONS[iconKey] || 'icons/svg/mystery-man.svg',
+
+        flags: {
+            [MODULE_ID]: {
+                fromStatblock: true,
+                sourceFile: filePath
+            }
+        },
+
+        system: {
+            description: {
+                value: markdownToHtml(action.desc)
+            },
+            type: {
+                value: 'monster',
+                subtype: ''
+            },
+            properties: new Set(activationType === null ? ['trait'] : []),
+            activities: {}
+        }
+    };
+
+    if (rechargeInfo.hasRecharge) {
+        item.system.uses = {
+            spent: 0,
+            max: '1',
+            recovery: [{
+                period: 'recharge',
+                type: 'recoverAll',
+                formula: String(rechargeInfo.rechargeValue)
+            }]
+        };
+    } else if (rechargeInfo.hasUses) {
+        item.system.uses = {
+            spent: 0,
+            max: String(rechargeInfo.usesValue),
+            recovery: [{
+                period: rechargeInfo.usesPeriod,
+                type: 'recoverAll'
+            }]
+        };
+    }
+
+    const activityId = typeof foundry !== 'undefined'
+        ? foundry.utils.randomID()
+        : Math.random().toString(36).substring(2, 18);
+
+    if (attackData?.isAttack) {
+        const attackType = attackData.isMelee ? 'melee' : 'ranged';
+        const classification = attackData.isWeapon ? 'weapon' : 'spell';
+
+        const damageParts = [];
+        if (attackData.damageFormula && attackData.damageType) {
+            const parsed = parseDamageFormula(attackData.damageFormula);
+            damageParts.push({
+                number: parsed.number,
+                denomination: parsed.denomination,
+                bonus: parsed.bonus,
+                types: new Set([attackData.damageType]),
+                custom: { enabled: false, formula: '' },
+                scaling: { mode: '', number: 1, formula: '' }
+            });
+        }
+
+        item.system.activities[activityId] = {
+            _id: activityId,
+            type: 'attack',
+            name: '',
+            activation: {
+                type: activationType || 'action',
+                condition: activationCondition
+            },
+            attack: {
+                ability: '',
+                bonus: String(attackData.attackBonus || 0),
+                critical: { threshold: null },
+                flat: true,
+                type: {
+                    value: attackType,
+                    classification: classification
+                }
+            },
+            damage: {
+                critical: { bonus: '' },
+                includeBase: false,
+                parts: damageParts
+            },
+            range: {
+                override: true,
+                value: attackData.reach || attackData.range || 5,
+                long: attackData.longRange || null,
+                units: 'ft'
+            }
+        };
+    } else if (activationType) {
+        const saveData = parseSaveAction(action.desc);
+        const targetData = parseTargeting(action.desc);
+        const target = buildTargetData(targetData);
+        const range = targetData.range ? {
+            override: true,
+            value: targetData.range,
+            long: targetData.longRange || null,
+            units: 'ft'
+        } : undefined;
+
+        if (saveData.isSave) {
+            const activity = {
+                _id: activityId,
+                type: 'save',
+                name: '',
+                activation: {
+                    type: activationType,
+                    condition: activationCondition
+                },
+                save: {
+                    ability: new Set([saveData.ability]),
+                    dc: {
+                        calculation: '',
+                        formula: String(saveData.dc)
+                    }
+                },
+                damage: {
+                    onSave: 'none',
+                    parts: []
+                }
+            };
+
+            if (target) {
+                activity.target = target;
+            }
+            if (range) {
+                activity.range = range;
+            }
+
+            item.system.activities[activityId] = activity;
+        } else {
+            const activity = {
+                _id: activityId,
+                type: 'utility',
+                name: '',
+                activation: {
+                    type: activationType,
+                    condition: activationCondition
+                }
+            };
+
+            if (target) {
+                activity.target = target;
+            }
+            if (range) {
+                activity.range = range;
+            }
+
+            item.system.activities[activityId] = activity;
+        }
+    } else {
+        // Trait with no activation - check for damage
+        const damageData = parseDamageFromDescription(action.desc);
+        if (damageData.hasDamage) {
+            const parsed = parseDamageFormula(damageData.formula);
+            const damageParts = [{
+                number: parsed.number,
+                denomination: parsed.denomination,
+                bonus: parsed.bonus,
+                types: damageData.type ? new Set([damageData.type]) : new Set(),
+                custom: { enabled: false, formula: '' },
+                scaling: { mode: '', number: 1, formula: '' }
+            }];
+
+            item.system.activities[activityId] = {
+                _id: activityId,
+                type: 'damage',
+                name: '',
+                activation: {
+                    type: '',
+                    condition: activationCondition
+                },
+                damage: {
+                    critical: { allow: false, bonus: '' },
+                    parts: damageParts
+                }
+            };
+        }
+    }
+
+    return item;
+}
+
+/**
+ * Parses a damage formula like "3d8+4" into components.
+ *
+ * @param {string} formula - Damage formula
+ * @returns {Object} Parsed components {number, denomination, bonus}
+ */
+function parseDamageFormula(formula) {
+    const result = { number: 0, denomination: 0, bonus: '' };
+    if (!formula) {
+        return result;
+    }
+
+    const match = formula.match(/(\d+)d(\d+)(?:\s*([+-]\s*\d+))?/);
+    if (match) {
+        result.number = parseInt(match[1], 10);
+        result.denomination = parseInt(match[2], 10);
+        if (match[3]) {
+            result.bonus = match[3].replace(/\s+/g, '');
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Builds a dnd5e target object from parsed targeting data.
+ *
+ * @param {Object} targetData - Parsed targeting data from parseTargeting
+ * @returns {Object|null} dnd5e target object or null if no targeting data
+ */
+function buildTargetData(targetData) {
+    if (!targetData) {
+        return null;
+    }
+
+    const hasArea = targetData.areaType && targetData.areaSize;
+    const hasAffects = targetData.affectsType;
+
+    if (!hasArea && !hasAffects) {
+        return null;
+    }
+
+    const target = {
+        override: true,
+        prompt: true
+    };
+
+    if (hasArea) {
+        target.template = {
+            count: '',
+            contiguous: false,
+            type: targetData.areaType,
+            size: String(targetData.areaSize),
+            width: '',
+            height: '',
+            units: 'ft'
+        };
+    }
+
+    if (hasAffects) {
+        target.affects = {
+            count: targetData.affectsCount ? String(targetData.affectsCount) : '',
+            type: targetData.affectsType,
+            choice: false,
+            special: ''
+        };
+    }
+
+    return target;
+}
+
+
+/**
+ * Creates a spell item from a compendium spell, customized for this creature.
+ *
+ * @param {Object} compendiumSpell - Spell document from compendium
+ * @param {Object} spellEntry - Parsed spell entry with usage info
+ * @param {Object} spellcastingInfo - Parsed spellcasting data
+ * @param {string} filePath - Source file path
+ * @returns {Object} Spell item data
+ */
+function createSpellFromCompendium(compendiumSpell, spellEntry, spellcastingInfo, filePath) {
+    const spellData = compendiumSpell.toObject();
+
+    // Set our tracking flags
+    spellData.flags = spellData.flags || {};
+    spellData.flags[MODULE_ID] = {
+        fromStatblock: true,
+        sourceFile: filePath
+    };
+
+    // Set preparation method based on usage
+    if (spellEntry.usage === 'atwill') {
+        spellData.system.method = 'atwill';
+        spellData.system.prepared = 1;
+    } else if (spellEntry.uses) {
+        spellData.system.method = 'innate';
+        spellData.system.prepared = 1;
+        // Set uses
+        spellData.system.uses = {
+            value: spellEntry.uses,
+            max: spellEntry.uses,
+            per: 'day',
+            recovery: ''
+        };
+    }
+
+    // Set spellcasting ability if known
+    if (spellcastingInfo.ability) {
+        spellData.system.ability = spellcastingInfo.ability;
+    }
+
+    return spellData;
+}
+
+/**
+ * Creates a basic spell item when compendium lookup fails.
+ *
+ * @param {Object} spellEntry - Parsed spell entry
+ * @param {Object} spellcastingInfo - Parsed spellcasting data
+ * @param {string} filePath - Source file path
+ * @returns {Object} Basic spell item data
+ */
+function createBasicSpell(spellEntry, spellcastingInfo, filePath) {
+    const uses = spellEntry.uses
+        ? { value: spellEntry.uses, max: spellEntry.uses, per: 'day', recovery: '' }
+        : null;
+
+    return {
+        name: spellEntry.name.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+        type: 'spell',
+        img: 'icons/svg/lightning.svg',
+
+        flags: {
+            [MODULE_ID]: {
+                fromStatblock: true,
+                sourceFile: filePath
+            }
+        },
+
+        system: {
+            description: {
+                value: spellEntry.note ? `<p>${spellEntry.note}</p>` : ''
+            },
+            level: 0, // Unknown level
+            school: 'evoc', // Default school
+            ability: spellcastingInfo.ability || '',
+            method: spellEntry.usage === 'atwill' ? 'atwill' : 'innate',
+            prepared: 1,
+            uses
+        }
+    };
+}
+
+/**
+ * Creates an equipment item from a compendium item.
+ *
+ * @param {Object} compendiumItem - Item document from compendium
+ * @param {number} quantity - Item quantity
+ * @param {string} filePath - Source file path
+ * @returns {Object} Equipment item data
+ */
+function createEquipmentFromCompendium(compendiumItem, quantity, filePath) {
+    const itemData = compendiumItem.toObject();
+
+    itemData.flags = itemData.flags || {};
+    itemData.flags[MODULE_ID] = {
+        fromStatblock: true,
+        sourceFile: filePath
+    };
+
+    // Set quantity if applicable
+    if (itemData.system.quantity !== undefined) {
+        itemData.system.quantity = quantity;
+    }
+
+    // Equip the item
+    if (itemData.system.equipped !== undefined) {
+        itemData.system.equipped = true;
+    }
+
+    return itemData;
+}
+
+/**
+ * Checks if a trait is the "Gear" trait.
+ *
+ * @param {Object} trait - Trait object
+ * @returns {boolean} True if this is the gear trait
+ */
+function isGearTrait(trait) {
+    if (!trait?.name) {
+        return false;
+    }
+    const name = trait.name.toLowerCase();
+    return name === 'gear' || name === 'equipment';
+}
+
+/**
+ * Checks if a trait is a spellcasting trait.
+ *
+ * @param {Object} trait - Trait object
+ * @returns {boolean} True if this is a spellcasting trait
+ */
+function isSpellcastingTrait(trait) {
+    if (!trait?.name) {
+        return false;
+    }
+    return trait.name.toLowerCase().includes('spellcasting');
+}
+
+function isLegendaryResistanceTrait(trait) {
+    if (!trait?.name) {
+        return false;
+    }
+    return /^Legendary Resistances?\s*\(\d+\/Day\)/i.test(trait.name);
+}
+
+/**
+ * Creates embedded item data from all action blocks in the statblock.
+ * This is the synchronous version that doesn't do compendium lookups.
+ * Use createEmbeddedItemsAsync for full functionality.
+ *
+ * @param {StatblockData} statblock - Parsed statblock data
+ * @returns {Object[]} Array of item data for createEmbeddedDocuments
+ */
+export function createEmbeddedItems(statblock) {
+    const items = [];
+    const filePath = statblock.filePath;
+
+    for (const trait of statblock.traits || []) {
+        if (isGearTrait(trait) || isSpellcastingTrait(trait) || isLegendaryResistanceTrait(trait)) {
+            continue;
+        }
+        items.push(createFeatItem(trait, null, filePath));
+    }
+
+    for (const action of statblock.actions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'action', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    for (const action of statblock.bonusActions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'bonus', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    for (const action of statblock.reactions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'reaction', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    for (const action of statblock.legendaryActions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'legendary', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    return items.filter(item => item !== null);
+}
+
+/**
+ * Creates embedded item data with compendium lookups for spells and equipment.
+ * This is the async version that provides full functionality.
+ *
+ * @param {StatblockData} statblock - Parsed statblock data
+ * @returns {Promise<Object[]>} Array of item data for createEmbeddedDocuments
+ */
+export async function createEmbeddedItemsAsync(statblock) {
+    const items = [];
+    const filePath = statblock.filePath;
+
+    // Parse spellcasting from the spells array
+    let spellcastingInfo = parseSpellcasting(statblock.spells);
+
+    // Also check for spellcasting traits (fallback for older format)
+    for (const trait of statblock.traits || []) {
+        if (isSpellcastingTrait(trait)) {
+            const traitSpellcasting = parseSpellcastingTrait(trait);
+            if (traitSpellcasting) {
+                // Merge info
+                spellcastingInfo.level = spellcastingInfo.level ?? traitSpellcasting.level;
+                spellcastingInfo.ability = spellcastingInfo.ability ?? traitSpellcasting.ability;
+                spellcastingInfo.saveDC = spellcastingInfo.saveDC ?? traitSpellcasting.saveDC;
+                spellcastingInfo.attackBonus = spellcastingInfo.attackBonus
+                    ?? traitSpellcasting.attackBonus;
+                spellcastingInfo.spells.push(...traitSpellcasting.spells);
+            }
+        }
+    }
+
+    // Parse gear from traits
+    const gearItems = extractGearFromTraits(statblock.traits);
+
+    // Collect all names for batch lookup
+    const spellNames = spellcastingInfo.spells.map(s => s.name);
+    const gearNames = gearItems.map(g => normalizeItemName(g.name));
+    const actionWeaponNames = [];
+
+    // Identify potential weapon actions for compendium lookup
+    for (const action of statblock.actions || []) {
+        const attackData = parseAttackAction(action.desc);
+        if (attackData.isAttack && !isMultiattack(action)) {
+            actionWeaponNames.push(extractWeaponName(action.name));
+        }
+    }
+
+    // Batch lookup compendium items
+    const [spellsMap, itemsMap] = await Promise.all([
+        findSpells(spellNames),
+        findItems([...gearNames, ...actionWeaponNames])
+    ]);
+
+    // Process traits (skip Gear and Spellcasting)
+    for (const trait of statblock.traits || []) {
+        if (isGearTrait(trait) || isSpellcastingTrait(trait) || isLegendaryResistanceTrait(trait)) {
+            continue;
+        }
+        items.push(createFeatItem(trait, null, filePath));
+    }
+
+    // Process actions
+    for (const action of statblock.actions || []) {
+        const attackData = parseAttackAction(action.desc);
+        if (attackData.isAttack && !isMultiattack(action)) {
+            // Check if we found this weapon in compendium
+            const weaponName = extractWeaponName(action.name).toLowerCase();
+            const compendiumWeapon = itemsMap.get(weaponName);
+
+            if (compendiumWeapon && compendiumWeapon.type === 'weapon') {
+                items.push(createEquipmentFromCompendium(compendiumWeapon, 1, filePath));
+            } else {
+                items.push(createFeatItem(action, 'action', filePath, attackData));
+            }
+        } else {
+            items.push(createFeatItem(action, 'action', filePath));
+        }
+    }
+
+    // Process bonus actions
+    for (const action of statblock.bonusActions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'bonus', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    // Process reactions
+    for (const action of statblock.reactions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'reaction', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    // Process legendary actions
+    for (const action of statblock.legendaryActions || []) {
+        const attackData = parseAttackAction(action.desc);
+        items.push(createFeatItem(action, 'legendary', filePath, attackData.isAttack ? attackData : null));
+    }
+
+    // Add spells
+    for (const spellEntry of spellcastingInfo.spells) {
+        const compendiumSpell = spellsMap.get(spellEntry.name);
+        if (compendiumSpell) {
+            items.push(createSpellFromCompendium(
+                compendiumSpell, spellEntry, spellcastingInfo, filePath
+            ));
+        } else {
+            items.push(createBasicSpell(spellEntry, spellcastingInfo, filePath));
+        }
+    }
+
+    // Add gear
+    for (const gear of gearItems) {
+        const normalizedName = normalizeItemName(gear.name);
+        const compendiumItem = itemsMap.get(normalizedName);
+        if (compendiumItem) {
+            items.push(createEquipmentFromCompendium(compendiumItem, gear.quantity, filePath));
+        }
+        // If not found in compendium, skip - we don't want to create generic loot
+    }
+
+    return items.filter(item => item !== null);
+}

--- a/src/statblock/adapters/dnd5e/mapper.test.js
+++ b/src/statblock/adapters/dnd5e/mapper.test.js
@@ -1,0 +1,687 @@
+import { mapToDnd5eActor, createEmbeddedItems } from './mapper';
+import StatblockData from '../../../domain/StatblockData';
+
+describe('mapToDnd5eActor', () => {
+    describe('name and type', () => {
+        it('should set name correctly', () => {
+            const statblock = new StatblockData({ name: 'Goblin Boss' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.name).toBe('Goblin Boss');
+        });
+
+        it('should default name to Unknown Creature when missing', () => {
+            const statblock = new StatblockData({});
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.name).toBe('Unknown Creature');
+        });
+
+        it('should set type to npc', () => {
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.type).toBe('npc');
+        });
+    });
+
+    describe('flags', () => {
+        it('should set sourceFile flag', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                filePath: '/vault/monsters/goblin.md'
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.flags['obsidian-bridge'].sourceFile).toBe('/vault/monsters/goblin.md');
+        });
+
+        it('should set importedAt flag', () => {
+            const before = Date.now();
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = mapToDnd5eActor(statblock);
+            const after = Date.now();
+
+            expect(result.flags['obsidian-bridge'].importedAt).toBeGreaterThanOrEqual(before);
+            expect(result.flags['obsidian-bridge'].importedAt).toBeLessThanOrEqual(after);
+        });
+    });
+
+    describe('abilities', () => {
+        it('should map abilities from StatblockData', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                abilities: { str: 18, dex: 14, con: 16, int: 10, wis: 12, cha: 8 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.abilities.str.value).toBe(18);
+            expect(result.system.abilities.dex.value).toBe(14);
+            expect(result.system.abilities.con.value).toBe(16);
+            expect(result.system.abilities.int.value).toBe(10);
+            expect(result.system.abilities.wis.value).toBe(12);
+            expect(result.system.abilities.cha.value).toBe(8);
+        });
+
+        it('should default abilities to 10 when not provided', () => {
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = mapToDnd5eActor(statblock);
+
+            for (const ability of ['str', 'dex', 'con', 'int', 'wis', 'cha']) {
+                expect(result.system.abilities[ability].value).toBe(10);
+            }
+        });
+
+        it('should set saving throw proficiency based on bonus', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                abilities: { str: 10, dex: 14, con: 10, int: 10, wis: 10, cha: 10 },
+                savingThrows: { dex: 5 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.abilities.dex.proficient).toBe(1);
+            expect(result.system.abilities.str.proficient).toBe(0);
+        });
+    });
+
+    describe('AC', () => {
+        it('should map AC correctly', () => {
+            const statblock = new StatblockData({ name: 'Test', ac: 15 });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.ac.flat).toBe(15);
+            expect(result.system.attributes.ac.calc).toBe('flat');
+        });
+
+        it('should default AC to 10 when not provided', () => {
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.ac.flat).toBe(10);
+        });
+    });
+
+    describe('HP and hitDice', () => {
+        it('should map HP correctly', () => {
+            const statblock = new StatblockData({ name: 'Test', hp: 45 });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.hp.value).toBe(45);
+            expect(result.system.attributes.hp.max).toBe(45);
+        });
+
+        it('should map hitDice to formula', () => {
+            const statblock = new StatblockData({ name: 'Test', hp: 45, hitDice: '6d8+18' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.hp.formula).toBe('6d8+18');
+        });
+
+        it('should default HP to 1 when not provided', () => {
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.hp.value).toBe(1);
+            expect(result.system.attributes.hp.max).toBe(1);
+        });
+    });
+
+    describe('movement', () => {
+        it('should map walk speed', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                speed: { walk: 30 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.movement.walk).toBe(30);
+        });
+
+        it('should map multiple movement types', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                speed: { walk: 30, fly: 60, swim: 30, climb: 20, burrow: 10 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.movement.walk).toBe(30);
+            expect(result.system.attributes.movement.fly).toBe(60);
+            expect(result.system.attributes.movement.swim).toBe(30);
+            expect(result.system.attributes.movement.climb).toBe(20);
+            expect(result.system.attributes.movement.burrow).toBe(10);
+        });
+
+        it('should set units to ft', () => {
+            const statblock = new StatblockData({ name: 'Test', speed: { walk: 30 } });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.movement.units).toBe('ft');
+        });
+    });
+
+    describe('senses', () => {
+        it('should map darkvision', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                senses: { darkvision: 60 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.senses.darkvision).toBe(60);
+        });
+
+        it('should map multiple sense types', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                senses: { darkvision: 60, blindsight: 30, tremorsense: 60, truesight: 120 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.senses.darkvision).toBe(60);
+            expect(result.system.attributes.senses.blindsight).toBe(30);
+            expect(result.system.attributes.senses.tremorsense).toBe(60);
+            expect(result.system.attributes.senses.truesight).toBe(120);
+        });
+
+        it('should not include passivePerception in senses (handled elsewhere)', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                senses: { darkvision: 60, passivePerception: 15 }
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.attributes.senses.darkvision).toBe(60);
+            expect(result.system.attributes.senses.passivePerception).toBeUndefined();
+        });
+    });
+
+    describe('creature type', () => {
+        it('should map standard creature type', () => {
+            const statblock = new StatblockData({ name: 'Test', type: 'humanoid' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.type.value).toBe('humanoid');
+            expect(result.system.details.type.custom).toBe('');
+        });
+
+        it('should map subtype', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                type: 'humanoid',
+                subtype: 'goblinoid'
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.type.subtype).toBe('goblinoid');
+        });
+
+        it('should handle custom creature type', () => {
+            const statblock = new StatblockData({ name: 'Test', type: 'Weird Thing' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.type.value).toBe('custom');
+            expect(result.system.details.type.custom).toBe('Weird Thing');
+        });
+    });
+
+    describe('challenge rating', () => {
+        it('should map integer CR', () => {
+            const statblock = new StatblockData({ name: 'Test', cr: 5 });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.cr).toBe(5);
+        });
+
+        it('should map fractional CR 1/4', () => {
+            const statblock = new StatblockData({ name: 'Test', cr: 0.25 });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.cr).toBe(0.25);
+        });
+
+        it('should map fractional CR 1/8', () => {
+            const statblock = new StatblockData({ name: 'Test', cr: 0.125 });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.cr).toBe(0.125);
+        });
+
+        it('should map fractional CR 1/2', () => {
+            const statblock = new StatblockData({ name: 'Test', cr: 0.5 });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.details.cr).toBe(0.5);
+        });
+    });
+
+    describe('size', () => {
+        it('should map valid size', () => {
+            const statblock = new StatblockData({ name: 'Test', size: 'lg' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.size).toBe('lg');
+        });
+
+        it('should default invalid size to med', () => {
+            const statblock = new StatblockData({ name: 'Test', size: 'invalid' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.size).toBe('med');
+        });
+
+        it('should map all valid size codes', () => {
+            const sizes = ['tiny', 'sm', 'med', 'lg', 'huge', 'grg'];
+            for (const size of sizes) {
+                const statblock = new StatblockData({ name: 'Test', size });
+                const result = mapToDnd5eActor(statblock);
+                expect(result.system.traits.size).toBe(size);
+            }
+        });
+    });
+
+    describe('damage immunities/resistances/vulnerabilities', () => {
+        it('should map damage immunities', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                damageImmunities: ['fire', 'poison']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.di.value).toEqual(new Set(['fire', 'poison']));
+        });
+
+        it('should map damage resistances', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                damageResistances: ['cold', 'lightning']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.dr.value).toEqual(new Set(['cold', 'lightning']));
+        });
+
+        it('should map damage vulnerabilities', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                damageVulnerabilities: ['radiant']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.dv.value).toEqual(new Set(['radiant']));
+        });
+
+        it('should filter out invalid damage types', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                damageImmunities: ['fire', 'invalid', 'poison']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.di.value).toEqual(new Set(['fire', 'poison']));
+        });
+    });
+
+    describe('condition immunities', () => {
+        it('should map condition immunities', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                conditionImmunities: ['charmed', 'frightened']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.ci.value).toEqual(new Set(['charmed', 'frightened']));
+        });
+
+        it('should filter out invalid conditions', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                conditionImmunities: ['charmed', 'invalid', 'poisoned']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.ci.value).toEqual(new Set(['charmed', 'poisoned']));
+        });
+    });
+
+    describe('languages', () => {
+        it('should map standard languages', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                languages: ['Common', 'Elvish']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.languages.value).toEqual(new Set(['common', 'elvish']));
+        });
+
+        it('should handle custom languages', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                languages: ['Common', 'Weird Alien Language']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.languages.value).toEqual(new Set(['common']));
+            expect(result.system.traits.languages.custom).toBe('Weird Alien Language');
+        });
+
+        it('should join multiple custom languages with semicolons', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                languages: ['Common', 'Weird Lang 1', 'Weird Lang 2']
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.traits.languages.custom).toBe('Weird Lang 1; Weird Lang 2');
+        });
+    });
+
+    describe('missing optional fields', () => {
+        it('should handle missing optional fields gracefully', () => {
+            const statblock = new StatblockData({ name: 'Minimal Creature' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.name).toBe('Minimal Creature');
+            expect(result.type).toBe('npc');
+            expect(result.system.attributes.ac.flat).toBe(10);
+            expect(result.system.attributes.hp.value).toBe(1);
+            expect(result.system.traits.size).toBe('med');
+            expect(result.system.details.cr).toBeNull();
+        });
+    });
+
+    describe('legendary resistances', () => {
+        it('should extract legendary resistance count from traits', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [
+                    { name: 'Legendary Resistance (3/Day)', desc: 'If the creature fails a saving throw, it can choose to succeed instead.' }
+                ]
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.resources.legres.max).toBe(3);
+            expect(result.system.resources.legres.spent).toBe(0);
+        });
+
+        it('should handle singular form', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [
+                    { name: 'Legendary Resistance (1/Day)', desc: 'Desc' }
+                ]
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.resources.legres.max).toBe(1);
+        });
+
+        it('should handle plural form with lowercase', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [
+                    { name: 'Legendary Resistances (3/day)', desc: 'Desc' }
+                ]
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.resources.legres.max).toBe(3);
+        });
+
+        it('should default to 0 when no legendary resistance trait', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [
+                    { name: 'Pack Tactics', desc: 'Something' }
+                ]
+            });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.resources.legres.max).toBe(0);
+        });
+
+        it('should default to 0 with no traits', () => {
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = mapToDnd5eActor(statblock);
+
+            expect(result.system.resources.legres.max).toBe(0);
+        });
+    });
+});
+
+describe('createEmbeddedItems', () => {
+    describe('traits', () => {
+        it('should create feat items for traits', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [
+                    { name: 'Pack Tactics', desc: 'The creature has advantage...' }
+                ]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Pack Tactics');
+            expect(result[0].type).toBe('feat');
+            expect(result[0].system.description.value).toContain('The creature has advantage...');
+        });
+    });
+
+    describe('actions', () => {
+        it('should create feat items for actions', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                actions: [
+                    { name: 'Multiattack', desc: 'Makes two attacks.' },
+                    { name: 'Bite', desc: 'Melee weapon attack...' }
+                ]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].name).toBe('Multiattack');
+            expect(result[1].name).toBe('Bite');
+        });
+    });
+
+    describe('bonus actions', () => {
+        it('should create feat items for bonus actions', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                bonusActions: [
+                    { name: 'Nimble Escape', desc: 'Takes Disengage or Hide.' }
+                ]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Nimble Escape');
+        });
+    });
+
+    describe('reactions', () => {
+        it('should create feat items for reactions', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                reactions: [
+                    { name: 'Parry', desc: 'Adds 2 to AC against one attack.' }
+                ]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Parry');
+        });
+    });
+
+    describe('legendary actions', () => {
+        it('should create feat items for legendary actions', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                legendaryActions: [
+                    { name: 'Attack', desc: 'Makes one attack.' },
+                    { name: 'Move', desc: 'Moves up to half speed.' }
+                ]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].name).toBe('Attack');
+            expect(result[1].name).toBe('Move');
+        });
+    });
+
+    describe('fromStatblock flag', () => {
+        it('should set fromStatblock flag on all items', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                filePath: '/vault/test.md',
+                traits: [{ name: 'Trait', desc: 'desc' }],
+                actions: [{ name: 'Action', desc: 'desc' }],
+                bonusActions: [{ name: 'Bonus', desc: 'desc' }],
+                reactions: [{ name: 'Reaction', desc: 'desc' }],
+                legendaryActions: [{ name: 'Legendary', desc: 'desc' }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(5);
+            for (const item of result) {
+                expect(item.flags['obsidian-bridge'].fromStatblock).toBe(true);
+                expect(item.flags['obsidian-bridge'].sourceFile).toBe('/vault/test.md');
+            }
+        });
+    });
+
+    describe('empty statblock', () => {
+        it('should return empty array for statblock with no action blocks', () => {
+            const statblock = new StatblockData({ name: 'Test' });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('combined action blocks', () => {
+        it('should combine all action types in order', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [{ name: 'Trait 1', desc: '' }],
+                actions: [{ name: 'Action 1', desc: '' }],
+                bonusActions: [{ name: 'Bonus 1', desc: '' }],
+                reactions: [{ name: 'Reaction 1', desc: '' }],
+                legendaryActions: [{ name: 'Legendary 1', desc: '' }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(5);
+            expect(result[0].name).toBe('Trait 1');
+            expect(result[1].name).toBe('Action 1');
+            expect(result[2].name).toBe('Bonus 1');
+            expect(result[3].name).toBe('Reaction 1');
+            expect(result[4].name).toBe('Legendary 1');
+        });
+    });
+
+    describe('recharge abilities', () => {
+        it('should parse Recharge 5-6 and set uses with recharge recovery', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                actions: [{ name: 'Breath Weapon (Recharge 5-6)', desc: 'Breathes fire.' }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Breath Weapon');
+            expect(result[0].system.uses).toBeDefined();
+            expect(result[0].system.uses.max).toBe('1');
+            expect(result[0].system.uses.spent).toBe(0);
+            expect(result[0].system.uses.recovery).toHaveLength(1);
+            expect(result[0].system.uses.recovery[0].period).toBe('recharge');
+            expect(result[0].system.uses.recovery[0].formula).toBe('5');
+        });
+    });
+
+    describe('reaction triggers', () => {
+        it('should extract trigger as activation condition for reactions', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                reactions: [{
+                    name: 'Parry',
+                    desc: '_Trigger:_ The goblin is hit by a melee attack. _Response:_ The goblin adds 2 to its AC.'
+                }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Parry');
+
+            const activityId = Object.keys(result[0].system.activities)[0];
+            const activity = result[0].system.activities[activityId];
+
+            expect(activity.activation.type).toBe('reaction');
+            expect(activity.activation.condition).toBe('The goblin is hit by a melee attack.');
+            expect(result[0].system.description.value).toContain('Trigger');
+            expect(result[0].system.description.value).toContain('Response');
+        });
+
+        it('should leave condition empty for reactions without trigger format', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                reactions: [{
+                    name: 'Opportunity Attack',
+                    desc: 'The creature can make an opportunity attack.'
+                }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            const activityId = Object.keys(result[0].system.activities)[0];
+            expect(result[0].system.activities[activityId].activation.condition).toBe('');
+        });
+    });
+
+    describe('daily use abilities', () => {
+        it('should parse X/Day and set uses with day recovery', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                actions: [{ name: 'Protective Magic (3/Day)', desc: 'Grants advantage.' }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Protective Magic');
+            expect(result[0].system.uses).toBeDefined();
+            expect(result[0].system.uses.max).toBe('3');
+            expect(result[0].system.uses.spent).toBe(0);
+            expect(result[0].system.uses.recovery).toHaveLength(1);
+            expect(result[0].system.uses.recovery[0].period).toBe('day');
+            expect(result[0].system.uses.recovery[0].type).toBe('recoverAll');
+        });
+
+        it('should parse X/Short Rest and set uses with sr recovery', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                actions: [{ name: 'Second Wind (1/Short Rest)', desc: 'Heals.' }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Second Wind');
+            expect(result[0].system.uses.max).toBe('1');
+            expect(result[0].system.uses.recovery[0].period).toBe('sr');
+        });
+
+        it('should parse X/Long Rest and set uses with lr recovery', () => {
+            const statblock = new StatblockData({
+                name: 'Test',
+                traits: [{ name: 'Divine Intervention (1/Long Rest)', desc: 'Once per day.' }]
+            });
+            const result = createEmbeddedItems(statblock);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe('Divine Intervention');
+            expect(result[0].system.uses.max).toBe('1');
+            expect(result[0].system.uses.recovery[0].period).toBe('lr');
+        });
+    });
+});

--- a/src/statblock/adapters/dnd5e/spellcastingParser.js
+++ b/src/statblock/adapters/dnd5e/spellcastingParser.js
@@ -101,7 +101,6 @@ function parseSpellcastingHeader(line) {
 function parseSpellListLine(line) {
     const spells = [];
 
-    // Determine usage type and count
     let usage = 'innate';
     let uses = null;
 

--- a/src/statblock/adapters/dnd5e/spellcastingParser.js
+++ b/src/statblock/adapters/dnd5e/spellcastingParser.js
@@ -1,0 +1,255 @@
+/**
+ * Parses Fantasy Statblocks spells array to extract spellcasting data.
+ *
+ * Expected format:
+ * spells:
+ * - The creature is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks).
+ * - At-Will: _bane_, _detect magic_, _mage hand_
+ * - 3/day: _hellish rebuke_
+ * - 2/day Each: _invisibility_, _cure wounds_
+ * - 1/day Each: _conjure elemental_, _tree stride_
+ */
+
+/**
+ * Parsed spellcasting information.
+ * @typedef {Object} ParsedSpellcasting
+ * @property {number|null} level - Spellcaster level
+ * @property {string|null} ability - Spellcasting ability (e.g., 'wis', 'cha')
+ * @property {number|null} saveDC - Spell save DC
+ * @property {number|null} attackBonus - Spell attack bonus
+ * @property {SpellEntry[]} spells - List of spells with usage info
+ */
+
+/**
+ * Individual spell entry.
+ * @typedef {Object} SpellEntry
+ * @property {string} name - Spell name (lowercase, no formatting)
+ * @property {string} usage - 'atwill', 'innate', or 'spell'
+ * @property {number|null} uses - Number of uses per day (null for at-will)
+ * @property {string|null} note - Additional note (e.g., "level 8 version")
+ */
+
+/**
+ * Ability name to abbreviation mapping.
+ */
+const ABILITY_MAP = {
+    strength: 'str',
+    dexterity: 'dex',
+    constitution: 'con',
+    intelligence: 'int',
+    wisdom: 'wis',
+    charisma: 'cha'
+};
+
+/**
+ * Parses the header line to extract spellcasting basics.
+ * Example: "The creature is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks)."
+ *
+ * @param {string} line - Header line
+ * @returns {Object} Partial ParsedSpellcasting
+ */
+function parseSpellcastingHeader(line) {
+    const result = {
+        level: null,
+        ability: null,
+        saveDC: null,
+        attackBonus: null
+    };
+
+    // Extract level: "5th-level spellcaster" or "5th level spellcaster"
+    const levelMatch = line.match(/(\d+)(?:st|nd|rd|th)[- ]level\s+spellcaster/i);
+    if (levelMatch) {
+        result.level = parseInt(levelMatch[1], 10);
+    }
+
+    // Extract ability: "spellcasting ability is Wisdom" or "using Wisdom as the spellcasting ability"
+    let abilityMatch = line.match(/spellcasting ability is (\w+)/i);
+    if (!abilityMatch) {
+        abilityMatch = line.match(/using (\w+) as the spellcasting ability/i);
+    }
+    if (abilityMatch) {
+        const abilityName = abilityMatch[1].toLowerCase();
+        result.ability = ABILITY_MAP[abilityName] || abilityName.substring(0, 3);
+    }
+
+    // Extract save DC: "spell save DC 15" or "DC 15"
+    const dcMatch = line.match(/(?:spell save )?DC (\d+)/i);
+    if (dcMatch) {
+        result.saveDC = parseInt(dcMatch[1], 10);
+    }
+
+    // Extract attack bonus: "+7 to hit"
+    const attackMatch = line.match(/\+(\d+) to hit/i);
+    if (attackMatch) {
+        result.attackBonus = parseInt(attackMatch[1], 10);
+    }
+
+    return result;
+}
+
+/**
+ * Parses a spell list line to extract spells and usage.
+ * Examples:
+ * - "At-Will: _bane_, _detect magic_, _mage hand_"
+ * - "3/day: _hellish rebuke_"
+ * - "2/day Each: _invisibility_, _cure wounds_"
+ * - "1/day Each: _conjure elemental (level 8 version)_, _tree stride_"
+ *
+ * @param {string} line - Spell list line
+ * @returns {SpellEntry[]} Array of spell entries
+ */
+function parseSpellListLine(line) {
+    const spells = [];
+
+    // Determine usage type and count
+    let usage = 'innate';
+    let uses = null;
+
+    // Match "At-Will:" or "at will:"
+    if (/at[- ]?will/i.test(line)) {
+        usage = 'atwill';
+        uses = null;
+    } else {
+        // Match "3/day:" or "3/day each:"
+        const usageMatch = line.match(/(\d+)\/day(?:\s+each)?/i);
+        if (usageMatch) {
+            uses = parseInt(usageMatch[1], 10);
+        }
+    }
+
+    // Extract spell names - they're italicized with underscores: _spell name_
+    const spellPattern = /_([^_]+)_/g;
+    let match;
+
+    while ((match = spellPattern.exec(line)) !== null) {
+        let spellName = match[1].trim();
+        let note = null;
+
+        // Check for parenthetical notes like "(level 8 version)"
+        const noteMatch = spellName.match(/\s*\(([^)]+)\)\s*$/);
+        if (noteMatch) {
+            note = noteMatch[1];
+            spellName = spellName.replace(/\s*\([^)]+\)\s*$/, '').trim();
+        }
+
+        spells.push({
+            name: spellName.toLowerCase(),
+            usage,
+            uses,
+            note
+        });
+    }
+
+    return spells;
+}
+
+/**
+ * Normalizes a spells array entry to a string.
+ * YAML parses "At-Will: spells" as {"At-Will": "spells"}.
+ *
+ * @param {string|Object} entry - Array entry (string or object)
+ * @returns {string} Normalized string
+ */
+function normalizeSpellEntry(entry) {
+    if (typeof entry === 'string') {
+        return entry;
+    }
+    if (entry && typeof entry === 'object') {
+        const keys = Object.keys(entry);
+        if (keys.length === 1) {
+            return `${keys[0]}: ${entry[keys[0]]}`;
+        }
+    }
+    return '';
+}
+
+/**
+ * Parses the Fantasy Statblocks spells array.
+ *
+ * @param {Array} spellsArray - Array of spell list entries (strings or objects)
+ * @returns {ParsedSpellcasting} Parsed spellcasting data
+ */
+export function parseSpellcasting(spellsArray) {
+    const result = {
+        level: null,
+        ability: null,
+        saveDC: null,
+        attackBonus: null,
+        spells: []
+    };
+
+    if (!spellsArray || !Array.isArray(spellsArray) || spellsArray.length === 0) {
+        return result;
+    }
+
+    for (const entry of spellsArray) {
+        const line = normalizeSpellEntry(entry);
+        if (!line) {
+            continue;
+        }
+
+        if (/spellcast(?:er|ing ability)/i.test(line)) {
+            const header = parseSpellcastingHeader(line);
+            result.level = header.level ?? result.level;
+            result.ability = header.ability ?? result.ability;
+            result.saveDC = header.saveDC ?? result.saveDC;
+            result.attackBonus = header.attackBonus ?? result.attackBonus;
+        }
+
+        if (/_[^_]+_/.test(line)) {
+            const spells = parseSpellListLine(line);
+            result.spells.push(...spells);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Extracts spellcasting info from a trait named "Spellcasting" or "Innate Spellcasting".
+ * This handles the older format where spellcasting is in a trait.
+ *
+ * @param {Object} trait - Trait object with name and desc
+ * @returns {ParsedSpellcasting|null} Parsed data or null if not spellcasting
+ */
+export function parseSpellcastingTrait(trait) {
+    if (!trait?.name || !trait?.desc) {
+        return null;
+    }
+
+    const name = trait.name.toLowerCase();
+    if (!name.includes('spellcasting')) {
+        return null;
+    }
+
+    const result = {
+        level: null,
+        ability: null,
+        saveDC: null,
+        attackBonus: null,
+        spells: []
+    };
+
+    const desc = trait.desc;
+
+    // Parse header info from description
+    const header = parseSpellcastingHeader(desc);
+    result.level = header.level;
+    result.ability = header.ability;
+    result.saveDC = header.saveDC;
+    result.attackBonus = header.attackBonus;
+
+    // Parse spell lists from description
+    // Split by common delimiters: newlines, periods followed by "At Will" or "X/Day"
+    const sections = desc.split(/(?=[*_]*(?:At[- ]?Will|[\d]+\/Day)[*_]*:)/i);
+
+    for (const section of sections) {
+        if (/_[^_]+_/.test(section) || /\*\*[^*]+\*\*/.test(section)) {
+            // Handle both _spell_ and **spell** formats
+            const spells = parseSpellListLine(section.replace(/\*\*/g, '_'));
+            result.spells.push(...spells);
+        }
+    }
+
+    return result;
+}

--- a/src/statblock/adapters/dnd5e/spellcastingParser.test.js
+++ b/src/statblock/adapters/dnd5e/spellcastingParser.test.js
@@ -1,0 +1,133 @@
+import { parseSpellcasting, parseSpellcastingTrait } from './spellcastingParser.js';
+
+describe('spellcastingParser', () => {
+    describe('parseSpellcasting', () => {
+        it('returns empty result for null input', () => {
+            const result = parseSpellcasting(null);
+            expect(result.spells).toEqual([]);
+            expect(result.level).toBeNull();
+        });
+
+        it('returns empty result for empty array', () => {
+            const result = parseSpellcasting([]);
+            expect(result.spells).toEqual([]);
+        });
+
+        it('parses spellcaster header line', () => {
+            const result = parseSpellcasting([
+                'The bugbear beastmage is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks).'
+            ]);
+
+            expect(result.level).toBe(5);
+            expect(result.ability).toBe('wis');
+            expect(result.saveDC).toBe(15);
+            expect(result.attackBonus).toBe(7);
+        });
+
+        it('parses at-will spells', () => {
+            const result = parseSpellcasting([
+                { 'At-Will': '_bane_, _detect magic_, _mage hand_, _thaumaturgy_' }
+            ]);
+
+            expect(result.spells).toHaveLength(4);
+            expect(result.spells[0]).toEqual({
+                name: 'bane',
+                usage: 'atwill',
+                uses: null,
+                note: null
+            });
+            expect(result.spells[1].name).toBe('detect magic');
+        });
+
+        it('parses daily spells with counts', () => {
+            const result = parseSpellcasting([
+                { '3/day': '_hellish rebuke_' },
+                { '2/day Each': '_invisibility_, _cure wounds_' }
+            ]);
+
+            expect(result.spells).toHaveLength(3);
+            expect(result.spells[0]).toEqual({
+                name: 'hellish rebuke',
+                usage: 'innate',
+                uses: 3,
+                note: null
+            });
+            expect(result.spells[1].uses).toBe(2);
+            expect(result.spells[2].uses).toBe(2);
+        });
+
+        it('parses spell notes in parentheses', () => {
+            const result = parseSpellcasting([
+                { '1/day Each': '_conjure elemental (level 8 version)_, _tree stride_' }
+            ]);
+
+            expect(result.spells).toHaveLength(2);
+            expect(result.spells[0]).toEqual({
+                name: 'conjure elemental',
+                usage: 'innate',
+                uses: 1,
+                note: 'level 8 version'
+            });
+            expect(result.spells[1].note).toBeNull();
+        });
+
+        it('parses full Fantasy Statblocks spells array', () => {
+            const result = parseSpellcasting([
+                'The bugbear beastmage is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks).',
+                { 'At-Will': '_bane_, _detect magic_, _mage hand_, _thaumaturgy_' },
+                { '3/day': '_hellish rebuke_' },
+                { '2/day Each': '_invisibility_, _cure wounds_, _conjure woodland beings_' },
+                { '1/day Each': '_conjure elemental_, _tree stride_' }
+            ]);
+
+            expect(result.level).toBe(5);
+            expect(result.ability).toBe('wis');
+            expect(result.saveDC).toBe(15);
+            expect(result.attackBonus).toBe(7);
+            expect(result.spells).toHaveLength(10);
+
+            // Check at-will spells (4: bane, detect magic, mage hand, thaumaturgy)
+            const atWillSpells = result.spells.filter(s => s.usage === 'atwill');
+            expect(atWillSpells).toHaveLength(4);
+
+            // Check 3/day spell
+            const threePerDay = result.spells.filter(s => s.uses === 3);
+            expect(threePerDay).toHaveLength(1);
+
+            // Check 2/day spells
+            const twoPerDay = result.spells.filter(s => s.uses === 2);
+            expect(twoPerDay).toHaveLength(3);
+
+            // Check 1/day spells
+            const onePerDay = result.spells.filter(s => s.uses === 1);
+            expect(onePerDay).toHaveLength(2);
+        });
+    });
+
+    describe('parseSpellcastingTrait', () => {
+        it('returns null for non-spellcasting trait', () => {
+            const result = parseSpellcastingTrait({
+                name: 'Keen Senses',
+                desc: 'The creature has advantage on Perception checks.'
+            });
+            expect(result).toBeNull();
+        });
+
+        it('returns null for null input', () => {
+            expect(parseSpellcastingTrait(null)).toBeNull();
+            expect(parseSpellcastingTrait({})).toBeNull();
+        });
+
+        it('parses spellcasting trait with markdown formatting', () => {
+            const result = parseSpellcastingTrait({
+                name: 'Spellcasting',
+                desc: 'The goblin casts one of the following spells, using Charisma as the spellcasting ability (spell save DC 19). **At Will:** _Shocking Grasp_, _Thaumaturgy_. **3/Day Each:** _Blink_, _Fear_.'
+            });
+
+            expect(result).not.toBeNull();
+            expect(result.ability).toBe('cha');
+            expect(result.saveDC).toBe(19);
+            expect(result.spells.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/statblock/extract.js
+++ b/src/statblock/extract.js
@@ -1,0 +1,50 @@
+/**
+ * Regex to match Fantasy Statblocks code blocks in markdown.
+ * Matches ```statblock followed by YAML content and closing ```.
+ * Uses non-greedy match to handle multiple statblocks in one document.
+ */
+const STATBLOCK_REGEX = /```statblock\r?\n([\s\S]+?)\r?\n```/g;
+
+/**
+ * Extracts all statblock code blocks from markdown content.
+ *
+ * @param {string} content - The markdown content to search
+ * @returns {{ yaml: string, startIndex: number, endIndex: number }[]} Array of extracted statblocks
+ */
+export function extractStatblocks(content) {
+    if (!content) {
+        return [];
+    }
+
+    const results = [];
+    let match;
+
+    // Reset regex lastIndex in case it was used before
+    STATBLOCK_REGEX.lastIndex = 0;
+
+    while ((match = STATBLOCK_REGEX.exec(content)) !== null) {
+        results.push({
+            yaml: match[1],
+            startIndex: match.index,
+            endIndex: match.index + match[0].length
+        });
+    }
+
+    return results;
+}
+
+/**
+ * Checks whether markdown content contains any statblock code blocks.
+ *
+ * @param {string} content - The markdown content to check
+ * @returns {boolean} True if content contains at least one statblock
+ */
+export function hasStatblocks(content) {
+    if (!content) {
+        return false;
+    }
+
+    // Reset regex lastIndex and test
+    STATBLOCK_REGEX.lastIndex = 0;
+    return STATBLOCK_REGEX.test(content);
+}

--- a/src/statblock/extract.test.js
+++ b/src/statblock/extract.test.js
@@ -1,0 +1,172 @@
+import { extractStatblocks, hasStatblocks } from './extract';
+
+describe('extractStatblocks', () => {
+    describe('basic extraction', () => {
+        it('should extract a single statblock', () => {
+            const content = `# Monster
+
+\`\`\`statblock
+name: Goblin
+hp: 7
+\`\`\`
+
+Some more text.`;
+            const result = extractStatblocks(content);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].yaml).toBe('name: Goblin\nhp: 7');
+            expect(result[0].startIndex).toBe(11);
+            expect(result[0].endIndex).toBe(46);
+        });
+
+        it('should extract multiple statblocks', () => {
+            const content = `\`\`\`statblock
+name: First
+\`\`\`
+
+\`\`\`statblock
+name: Second
+\`\`\``;
+            const result = extractStatblocks(content);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].yaml).toBe('name: First');
+            expect(result[1].yaml).toBe('name: Second');
+        });
+
+        it('should capture full YAML content with multiple lines', () => {
+            const content = `\`\`\`statblock
+name: Test Creature
+size: Medium
+type: humanoid
+ac: 15
+hp: 50
+\`\`\``;
+            const result = extractStatblocks(content);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].yaml).toContain('name: Test Creature');
+            expect(result[0].yaml).toContain('hp: 50');
+        });
+    });
+
+    describe('empty and null handling', () => {
+        it('should return empty array for empty string', () => {
+            expect(extractStatblocks('')).toEqual([]);
+        });
+
+        it('should return empty array for null', () => {
+            expect(extractStatblocks(null)).toEqual([]);
+        });
+
+        it('should return empty array for undefined', () => {
+            expect(extractStatblocks(undefined)).toEqual([]);
+        });
+
+        it('should return empty array when no statblocks exist', () => {
+            const content = 'Just regular markdown without statblocks.';
+            expect(extractStatblocks(content)).toEqual([]);
+        });
+    });
+
+    describe('non-statblock code blocks', () => {
+        it('should not extract regular code blocks', () => {
+            const content = `\`\`\`javascript
+const x = 1;
+\`\`\``;
+            expect(extractStatblocks(content)).toEqual([]);
+        });
+
+        it('should not extract code blocks with similar names', () => {
+            const content = `\`\`\`statblocks
+name: Not a statblock
+\`\`\``;
+            expect(extractStatblocks(content)).toEqual([]);
+        });
+
+        it('should only extract statblock blocks among mixed code blocks', () => {
+            const content = `\`\`\`javascript
+const x = 1;
+\`\`\`
+
+\`\`\`statblock
+name: Goblin
+\`\`\`
+
+\`\`\`python
+print("hello")
+\`\`\``;
+            const result = extractStatblocks(content);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].yaml).toBe('name: Goblin');
+        });
+    });
+
+    describe('CRLF line endings', () => {
+        it('should handle Windows-style line endings', () => {
+            const content = '```statblock\r\nname: Goblin\r\nhp: 7\r\n```';
+            const result = extractStatblocks(content);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].yaml).toBe('name: Goblin\r\nhp: 7');
+        });
+    });
+
+    describe('index tracking', () => {
+        it('should track correct start and end indices', () => {
+            const content = '```statblock\nname: Test\n```';
+            const result = extractStatblocks(content);
+
+            expect(result[0].startIndex).toBe(0);
+            expect(result[0].endIndex).toBe(content.length);
+        });
+
+        it('should track indices for second statblock correctly', () => {
+            const content = `\`\`\`statblock
+name: First
+\`\`\`
+text between
+\`\`\`statblock
+name: Second
+\`\`\``;
+            const result = extractStatblocks(content);
+
+            expect(result[1].startIndex).toBeGreaterThan(result[0].endIndex);
+            expect(content.substring(result[1].startIndex, result[1].endIndex)).toContain('name: Second');
+        });
+    });
+});
+
+describe('hasStatblocks', () => {
+    it('should return true when statblock exists', () => {
+        const content = `\`\`\`statblock
+name: Goblin
+\`\`\``;
+        expect(hasStatblocks(content)).toBe(true);
+    });
+
+    it('should return false when no statblock exists', () => {
+        const content = 'Regular markdown content.';
+        expect(hasStatblocks(content)).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+        expect(hasStatblocks('')).toBe(false);
+    });
+
+    it('should return false for null', () => {
+        expect(hasStatblocks(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+        expect(hasStatblocks(undefined)).toBe(false);
+    });
+
+    it('should return false for other code blocks', () => {
+        const content = `\`\`\`javascript
+const x = 1;
+\`\`\``;
+        expect(hasStatblocks(content)).toBe(false);
+    });
+});

--- a/src/statblock/parse.js
+++ b/src/statblock/parse.js
@@ -1,0 +1,288 @@
+import jsyaml from 'js-yaml';
+import StatblockData from '../domain/StatblockData.js';
+
+/**
+ * Size string to dnd5e abbreviation mapping.
+ * Fantasy Statblocks uses full words; Foundry uses abbreviations.
+ */
+const SIZE_MAP = {
+    tiny: 'tiny',
+    small: 'sm',
+    medium: 'med',
+    large: 'lg',
+    huge: 'huge',
+    gargantuan: 'grg'
+};
+
+/**
+ * Normalizes size string to dnd5e abbreviation.
+ *
+ * @param {string} size - Size string like "Small" or "Medium"
+ * @returns {string} Abbreviated size like "sm" or "med"
+ */
+function normalizeSize(size) {
+    if (!size) {
+        return '';
+    }
+    const lower = size.toLowerCase().trim();
+    return SIZE_MAP[lower] || lower;
+}
+
+/**
+ * Extracts numeric AC value from AC field.
+ * AC can be a number (14) or string ("20 (plate armor, shield)").
+ *
+ * @param {number|string} ac - AC value from statblock
+ * @returns {number|null} Numeric AC value
+ */
+function normalizeAC(ac) {
+    if (ac === null || ac === undefined) {
+        return null;
+    }
+    if (typeof ac === 'number') {
+        return ac;
+    }
+    const match = String(ac).match(/^(\d+)/);
+    return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Converts stats array to abilities object.
+ * Input: [10, 15, 14, 8, 12, 10]
+ * Output: {str: 10, dex: 15, con: 14, int: 8, wis: 12, cha: 10}
+ *
+ * @param {number[]} stats - Array of 6 ability scores in order
+ * @returns {Object|null} Abilities object or null if invalid
+ */
+function normalizeStats(stats) {
+    if (!Array.isArray(stats) || stats.length !== 6) {
+        return null;
+    }
+    return {
+        str: stats[0],
+        dex: stats[1],
+        con: stats[2],
+        int: stats[3],
+        wis: stats[4],
+        cha: stats[5]
+    };
+}
+
+/**
+ * Converts saves array to saving throws object.
+ * Input: [{Dex: +4}, {Con: +6}]
+ * Output: {dex: 4, con: 6}
+ *
+ * @param {Object[]} saves - Array of save objects
+ * @returns {Object|null} Saving throws object or null if invalid
+ */
+function normalizeSaves(saves) {
+    if (!Array.isArray(saves)) {
+        return null;
+    }
+    const result = {};
+    for (const save of saves) {
+        for (const [key, value] of Object.entries(save)) {
+            const ability = key.toLowerCase();
+            // Handle both "+4" and 4 formats
+            const bonus = typeof value === 'string'
+                ? parseInt(value.replace(/^\+/, ''), 10)
+                : value;
+            result[ability] = bonus;
+        }
+    }
+    return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Converts skillsaves array to skills object.
+ * Input: [{Stealth: +6}, {Perception: +4}]
+ * Output: {stealth: 6, perception: 4}
+ *
+ * @param {Object[]} skillsaves - Array of skill objects
+ * @returns {Object|null} Skills object or null if invalid
+ */
+function normalizeSkillsaves(skillsaves) {
+    if (!Array.isArray(skillsaves)) {
+        return null;
+    }
+    const result = {};
+    for (const skill of skillsaves) {
+        for (const [key, value] of Object.entries(skill)) {
+            const skillName = key.toLowerCase();
+            // Handle both "+6" and 6 formats
+            const bonus = typeof value === 'string'
+                ? parseInt(value.replace(/^\+/, ''), 10)
+                : value;
+            result[skillName] = bonus;
+        }
+    }
+    return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Parses speed string into speed object.
+ * Input: "30 ft., fly 60 ft., swim 30 ft."
+ * Output: {walk: 30, fly: 60, swim: 30}
+ *
+ * @param {string} speedStr - Speed string from statblock
+ * @returns {Object|null} Speed object or null if invalid
+ */
+function normalizeSpeed(speedStr) {
+    if (!speedStr) {
+        return null;
+    }
+
+    const result = {};
+    const parts = String(speedStr).split(',').map(p => p.trim());
+
+    for (const part of parts) {
+        // Match patterns like "30 ft." (walk), "fly 60 ft.", "swim 30 ft."
+        const match = part.match(/^(?:(\w+)\s+)?(\d+)\s*ft\.?/i);
+        if (match) {
+            const type = match[1] ? match[1].toLowerCase() : 'walk';
+            const value = parseInt(match[2], 10);
+            result[type] = value;
+        }
+    }
+
+    return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Normalizes CR to a number.
+ * Handles fractions like "1/4" -> 0.25, "1/8" -> 0.125
+ *
+ * @param {string|number} cr - Challenge rating
+ * @returns {number|null} Numeric CR value
+ */
+function normalizeCR(cr) {
+    if (cr === null || cr === undefined) {
+        return null;
+    }
+    if (typeof cr === 'number') {
+        return cr;
+    }
+    const crStr = String(cr).trim();
+
+    // Handle fractions
+    const fractionMatch = crStr.match(/^(\d+)\/(\d+)$/);
+    if (fractionMatch) {
+        return parseInt(fractionMatch[1], 10) / parseInt(fractionMatch[2], 10);
+    }
+
+    const parsed = parseFloat(crStr);
+    return isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Splits comma-separated string into array.
+ * Input: "Common, Goblin"
+ * Output: ['Common', 'Goblin']
+ *
+ * @param {string} str - Comma-separated string
+ * @returns {string[]|null} Array of trimmed strings or null if empty
+ */
+function normalizeCommaList(str) {
+    if (!str) {
+        return null;
+    }
+    const items = String(str).split(',').map(s => s.trim()).filter(s => s.length > 0);
+    return items.length > 0 ? items : null;
+}
+
+/**
+ * Parses senses string into senses object.
+ * Input: "darkvision 60 ft., passive Perception 15"
+ * Output: {darkvision: 60, passivePerception: 15}
+ *
+ * @param {string} sensesStr - Senses string from statblock
+ * @returns {Object|null} Senses object or null if invalid
+ */
+function normalizeSenses(sensesStr) {
+    if (!sensesStr) {
+        return null;
+    }
+
+    const result = {};
+    const parts = String(sensesStr).split(',').map(p => p.trim());
+
+    for (const part of parts) {
+        // Match "passive Perception 15"
+        const passiveMatch = part.match(/passive\s+perception\s+(\d+)/i);
+        if (passiveMatch) {
+            result.passivePerception = parseInt(passiveMatch[1], 10);
+            continue;
+        }
+
+        // Match sense types like "darkvision 60 ft.", "blindsight 10 ft."
+        const senseMatch = part.match(/^(\w+)\s+(\d+)\s*ft\.?/i);
+        if (senseMatch) {
+            const senseType = senseMatch[1].toLowerCase();
+            result[senseType] = parseInt(senseMatch[2], 10);
+        }
+    }
+
+    return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Parses a Fantasy Statblock YAML string into a StatblockData object.
+ *
+ * @param {string} yaml - YAML content from statblock code block
+ * @param {string} filePath - Source file path for error tracking
+ * @returns {StatblockData} Parsed and normalized statblock data
+ * @throws {Error} If YAML parsing fails
+ */
+export function parseStatblock(yaml, filePath = '') {
+    const data = jsyaml.load(yaml);
+
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error(`Invalid statblock YAML in ${filePath}: expected object`);
+    }
+
+    return new StatblockData({
+        // Identity
+        name: data.name || '',
+        filePath,
+
+        // Core stats
+        size: normalizeSize(data.size),
+        type: data.type || '',
+        subtype: data.subtype || '',
+        alignment: data.alignment || '',
+
+        // Combat
+        ac: normalizeAC(data.ac),
+        hp: data.hp ?? null,
+        hitDice: data.hit_dice || '',
+        speed: normalizeSpeed(data.speed),
+
+        // Abilities
+        abilities: normalizeStats(data.stats),
+        savingThrows: normalizeSaves(data.saves),
+        skills: normalizeSkillsaves(data.skillsaves),
+
+        // Traits
+        damageVulnerabilities: normalizeCommaList(data.damage_vulnerabilities),
+        damageResistances: normalizeCommaList(data.damage_resistances),
+        damageImmunities: normalizeCommaList(data.damage_immunities),
+        conditionImmunities: normalizeCommaList(data.condition_immunities),
+        senses: normalizeSenses(data.senses),
+        languages: normalizeCommaList(data.languages),
+
+        // Challenge
+        cr: normalizeCR(data.cr),
+
+        // Features and Actions - pass through as-is
+        traits: data.traits || null,
+        actions: data.actions || null,
+        bonusActions: data.bonus_actions || null,
+        reactions: data.reactions || null,
+        legendaryActions: data.legendary_actions || null,
+        legendaryDescription: data.legendary_description || '',
+
+        // Spellcasting
+        spells: data.spells || null
+    });
+}

--- a/src/statblock/parse.js
+++ b/src/statblock/parse.js
@@ -242,47 +242,32 @@ export function parseStatblock(yaml, filePath = '') {
     }
 
     return new StatblockData({
-        // Identity
         name: data.name || '',
         filePath,
-
-        // Core stats
         size: normalizeSize(data.size),
         type: data.type || '',
         subtype: data.subtype || '',
         alignment: data.alignment || '',
-
-        // Combat
         ac: normalizeAC(data.ac),
         hp: data.hp ?? null,
         hitDice: data.hit_dice || '',
         speed: normalizeSpeed(data.speed),
-
-        // Abilities
         abilities: normalizeStats(data.stats),
         savingThrows: normalizeSaves(data.saves),
         skills: normalizeSkillsaves(data.skillsaves),
-
-        // Traits
         damageVulnerabilities: normalizeCommaList(data.damage_vulnerabilities),
         damageResistances: normalizeCommaList(data.damage_resistances),
         damageImmunities: normalizeCommaList(data.damage_immunities),
         conditionImmunities: normalizeCommaList(data.condition_immunities),
         senses: normalizeSenses(data.senses),
         languages: normalizeCommaList(data.languages),
-
-        // Challenge
         cr: normalizeCR(data.cr),
-
-        // Features and Actions - pass through as-is
         traits: data.traits || null,
         actions: data.actions || null,
         bonusActions: data.bonus_actions || null,
         reactions: data.reactions || null,
         legendaryActions: data.legendary_actions || null,
         legendaryDescription: data.legendary_description || '',
-
-        // Spellcasting
         spells: data.spells || null
     });
 }

--- a/src/statblock/parse.test.js
+++ b/src/statblock/parse.test.js
@@ -1,0 +1,472 @@
+import { parseStatblock } from './parse';
+import StatblockData from '../domain/StatblockData';
+
+describe('parseStatblock', () => {
+    describe('basic parsing', () => {
+        it('should return a StatblockData instance', () => {
+            const yaml = 'name: Test Creature';
+            const result = parseStatblock(yaml);
+
+            expect(result).toBeInstanceOf(StatblockData);
+        });
+
+        it('should parse name and filePath', () => {
+            const yaml = 'name: Goblin Boss';
+            const result = parseStatblock(yaml, '/path/to/file.md');
+
+            expect(result.name).toBe('Goblin Boss');
+            expect(result.filePath).toBe('/path/to/file.md');
+        });
+
+        it('should parse type and subtype', () => {
+            const yaml = `name: Test
+type: humanoid
+subtype: Goblinoid`;
+            const result = parseStatblock(yaml);
+
+            expect(result.type).toBe('humanoid');
+            expect(result.subtype).toBe('Goblinoid');
+        });
+
+        it('should parse alignment', () => {
+            const yaml = `name: Test
+alignment: Chaotic Evil`;
+            const result = parseStatblock(yaml);
+
+            expect(result.alignment).toBe('Chaotic Evil');
+        });
+    });
+
+    describe('size normalization', () => {
+        it('should normalize Small to sm', () => {
+            const yaml = `name: Test
+size: Small`;
+            const result = parseStatblock(yaml);
+
+            expect(result.size).toBe('sm');
+        });
+
+        it('should normalize Medium to med', () => {
+            const yaml = `name: Test
+size: Medium`;
+            const result = parseStatblock(yaml);
+
+            expect(result.size).toBe('med');
+        });
+
+        it('should normalize Large to lg', () => {
+            const yaml = `name: Test
+size: Large`;
+            const result = parseStatblock(yaml);
+
+            expect(result.size).toBe('lg');
+        });
+
+        it('should normalize Gargantuan to grg', () => {
+            const yaml = `name: Test
+size: Gargantuan`;
+            const result = parseStatblock(yaml);
+
+            expect(result.size).toBe('grg');
+        });
+
+        it('should handle lowercase input', () => {
+            const yaml = `name: Test
+size: medium`;
+            const result = parseStatblock(yaml);
+
+            expect(result.size).toBe('med');
+        });
+
+        it('should preserve tiny and huge as-is', () => {
+            expect(parseStatblock('name: Test\nsize: Tiny').size).toBe('tiny');
+            expect(parseStatblock('name: Test\nsize: Huge').size).toBe('huge');
+        });
+    });
+
+    describe('AC normalization', () => {
+        it('should parse numeric AC', () => {
+            const yaml = `name: Test
+ac: 14`;
+            const result = parseStatblock(yaml);
+
+            expect(result.ac).toBe(14);
+        });
+
+        it('should extract numeric value from AC string with armor', () => {
+            const yaml = `name: Test
+ac: 20 (plate armor, shield)`;
+            const result = parseStatblock(yaml);
+
+            expect(result.ac).toBe(20);
+        });
+
+        it('should handle AC string without parentheses', () => {
+            const yaml = `name: Test
+ac: "15"`;
+            const result = parseStatblock(yaml);
+
+            expect(result.ac).toBe(15);
+        });
+    });
+
+    describe('stats array normalization', () => {
+        it('should convert stats array to abilities object', () => {
+            const yaml = `name: Test
+stats: [10, 15, 14, 8, 12, 10]`;
+            const result = parseStatblock(yaml);
+
+            expect(result.abilities).toEqual({
+                str: 10,
+                dex: 15,
+                con: 14,
+                int: 8,
+                wis: 12,
+                cha: 10
+            });
+        });
+
+        it('should use default abilities for invalid stats array', () => {
+            const yaml = `name: Test
+stats: [10, 15]`;
+            const result = parseStatblock(yaml);
+
+            expect(result.abilities).toEqual({ str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 });
+        });
+    });
+
+    describe('saves array normalization', () => {
+        it('should convert saves array to saving throws object', () => {
+            const yaml = `name: Test
+saves:
+- Dex: +4
+- Con: +6`;
+            const result = parseStatblock(yaml);
+
+            expect(result.savingThrows).toEqual({
+                dex: 4,
+                con: 6
+            });
+        });
+
+        it('should handle saves without plus sign', () => {
+            const yaml = `name: Test
+saves:
+- Int: 7
+- Wis: 4`;
+            const result = parseStatblock(yaml);
+
+            expect(result.savingThrows).toEqual({
+                int: 7,
+                wis: 4
+            });
+        });
+
+        it('should lowercase ability names', () => {
+            const yaml = `name: Test
+saves:
+- DEX: +4`;
+            const result = parseStatblock(yaml);
+
+            expect(result.savingThrows).toEqual({ dex: 4 });
+        });
+    });
+
+    describe('skillsaves array normalization', () => {
+        it('should convert skillsaves array to skills object', () => {
+            const yaml = `name: Test
+skillsaves:
+- Stealth: +6
+- Perception: +4`;
+            const result = parseStatblock(yaml);
+
+            expect(result.skills).toEqual({
+                stealth: 6,
+                perception: 4
+            });
+        });
+
+        it('should lowercase skill names', () => {
+            const yaml = `name: Test
+skillsaves:
+- STEALTH: +6`;
+            const result = parseStatblock(yaml);
+
+            expect(result.skills).toEqual({ stealth: 6 });
+        });
+    });
+
+    describe('speed string normalization', () => {
+        it('should parse walk speed', () => {
+            const yaml = `name: Test
+speed: 30 ft.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.speed).toEqual({ walk: 30 });
+        });
+
+        it('should parse multiple speed types', () => {
+            const yaml = `name: Test
+speed: 30 ft., fly 60 ft., swim 30 ft.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.speed).toEqual({
+                walk: 30,
+                fly: 60,
+                swim: 30
+            });
+        });
+
+        it('should handle speed without period', () => {
+            const yaml = `name: Test
+speed: 30 ft`;
+            const result = parseStatblock(yaml);
+
+            expect(result.speed).toEqual({ walk: 30 });
+        });
+    });
+
+    describe('CR normalization', () => {
+        it('should parse integer CR', () => {
+            const yaml = `name: Test
+cr: 5`;
+            const result = parseStatblock(yaml);
+
+            expect(result.cr).toBe(5);
+        });
+
+        it('should parse fraction 1/4', () => {
+            const yaml = `name: Test
+cr: 1/4`;
+            const result = parseStatblock(yaml);
+
+            expect(result.cr).toBe(0.25);
+        });
+
+        it('should parse fraction 1/8', () => {
+            const yaml = `name: Test
+cr: 1/8`;
+            const result = parseStatblock(yaml);
+
+            expect(result.cr).toBe(0.125);
+        });
+
+        it('should parse fraction 1/2', () => {
+            const yaml = `name: Test
+cr: 1/2`;
+            const result = parseStatblock(yaml);
+
+            expect(result.cr).toBe(0.5);
+        });
+
+        it('should handle string CR', () => {
+            const yaml = `name: Test
+cr: "12"`;
+            const result = parseStatblock(yaml);
+
+            expect(result.cr).toBe(12);
+        });
+    });
+
+    describe('comma-separated strings normalization', () => {
+        it('should split languages into array', () => {
+            const yaml = `name: Test
+languages: Common, Goblin`;
+            const result = parseStatblock(yaml);
+
+            expect(result.languages).toEqual(['Common', 'Goblin']);
+        });
+
+        it('should split condition immunities into array', () => {
+            const yaml = `name: Test
+condition_immunities: Charmed, Frightened`;
+            const result = parseStatblock(yaml);
+
+            expect(result.conditionImmunities).toEqual(['Charmed', 'Frightened']);
+        });
+
+        it('should handle single value', () => {
+            const yaml = `name: Test
+languages: Goblin`;
+            const result = parseStatblock(yaml);
+
+            expect(result.languages).toEqual(['Goblin']);
+        });
+    });
+
+    describe('senses string normalization', () => {
+        it('should parse darkvision', () => {
+            const yaml = `name: Test
+senses: darkvision 60 ft.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.senses).toEqual({ darkvision: 60 });
+        });
+
+        it('should parse passive Perception', () => {
+            const yaml = `name: Test
+senses: passive Perception 15`;
+            const result = parseStatblock(yaml);
+
+            expect(result.senses).toEqual({ passivePerception: 15 });
+        });
+
+        it('should parse multiple senses', () => {
+            const yaml = `name: Test
+senses: Blindsight 10 ft., Darkvision 60 ft., passive Perception 10`;
+            const result = parseStatblock(yaml);
+
+            expect(result.senses).toEqual({
+                blindsight: 10,
+                darkvision: 60,
+                passivePerception: 10
+            });
+        });
+    });
+
+    describe('action blocks pass-through', () => {
+        it('should pass through traits array', () => {
+            const yaml = `name: Test
+traits:
+- name: Cruel
+  desc: Deals extra damage.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.traits).toEqual([{ name: 'Cruel', desc: 'Deals extra damage.' }]);
+        });
+
+        it('should pass through actions array', () => {
+            const yaml = `name: Test
+actions:
+- name: Multiattack
+  desc: Makes two attacks.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.actions).toEqual([{ name: 'Multiattack', desc: 'Makes two attacks.' }]);
+        });
+
+        it('should pass through bonus_actions as bonusActions', () => {
+            const yaml = `name: Test
+bonus_actions:
+- name: Nimble Escape
+  desc: Takes Disengage or Hide.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.bonusActions).toEqual([{ name: 'Nimble Escape', desc: 'Takes Disengage or Hide.' }]);
+        });
+
+        it('should pass through reactions', () => {
+            const yaml = `name: Test
+reactions:
+- name: Parry
+  desc: Adds to AC.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.reactions).toEqual([{ name: 'Parry', desc: 'Adds to AC.' }]);
+        });
+
+        it('should pass through legendary_actions as legendaryActions', () => {
+            const yaml = `name: Test
+legendary_actions:
+- name: Attack
+  desc: Makes one attack.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.legendaryActions).toEqual([{ name: 'Attack', desc: 'Makes one attack.' }]);
+        });
+
+        it('should pass through legendary_description as legendaryDescription', () => {
+            const yaml = `name: Test
+legendary_description: Can take 3 legendary actions.`;
+            const result = parseStatblock(yaml);
+
+            expect(result.legendaryDescription).toBe('Can take 3 legendary actions.');
+        });
+
+        it('should pass through spells array', () => {
+            const yaml = `name: Test
+spells:
+- The creature is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks).
+- At-Will: _bane_, _detect magic_
+- 3/day: _hellish rebuke_`;
+            const result = parseStatblock(yaml);
+
+            expect(result.spells).toEqual([
+                'The creature is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 15, +7 to hit with spell attacks).',
+                { 'At-Will': '_bane_, _detect magic_' },
+                { '3/day': '_hellish rebuke_' }
+            ]);
+        });
+    });
+
+    describe('real-world statblock parsing', () => {
+        it('should parse Goblin Boss statblock', () => {
+            const yaml = `name: Goblin Boss
+size: Small
+type: humanoid
+subtype: Goblinoid
+alignment: Chaotic Neutral
+ac: 14
+hp: 21
+hit_dice: 6d6
+speed: 30 ft.
+stats: [10, 15, 10, 10, 8, 10]
+saves:
+- Dex: +2
+skillsaves:
+- Stealth: +6
+senses: darkvision 60 ft., passive Perception 9
+languages: Goblin
+cr: 1
+traits:
+- name: Cruel
+  desc: Deals extra damage.`;
+            const result = parseStatblock(yaml, '/path/to/Goblin Boss.md');
+
+            expect(result.name).toBe('Goblin Boss');
+            expect(result.size).toBe('sm');
+            expect(result.type).toBe('humanoid');
+            expect(result.ac).toBe(14);
+            expect(result.hp).toBe(21);
+            expect(result.hitDice).toBe('6d6');
+            expect(result.speed).toEqual({ walk: 30 });
+            expect(result.abilities.dex).toBe(15);
+            expect(result.savingThrows).toEqual({ dex: 2 });
+            expect(result.skills).toEqual({ stealth: 6 });
+            expect(result.senses).toEqual({ darkvision: 60, passivePerception: 9 });
+            expect(result.languages).toEqual(['Goblin']);
+            expect(result.cr).toBe(1);
+        });
+
+        it('should parse Hobgoblin General statblock with complex AC', () => {
+            const yaml = `name: Hobgoblin General
+size: Medium
+type: humanoid
+ac: 20 (plate armor, shield)
+hp: 237
+cr: 12
+condition_immunities: Charmed, Frightened`;
+            const result = parseStatblock(yaml);
+
+            expect(result.name).toBe('Hobgoblin General');
+            expect(result.size).toBe('med');
+            expect(result.ac).toBe(20);
+            expect(result.hp).toBe(237);
+            expect(result.cr).toBe(12);
+            expect(result.conditionImmunities).toEqual(['Charmed', 'Frightened']);
+        });
+    });
+
+    describe('error handling', () => {
+        it('should throw on invalid YAML', () => {
+            const yaml = `name: [invalid
+yaml: structure`;
+            expect(() => parseStatblock(yaml, '/test.md')).toThrow();
+        });
+
+        it('should throw on non-object YAML', () => {
+            const yaml = '- item1\n- item2';
+            expect(() => parseStatblock(yaml, '/test.md')).toThrow(/expected object/);
+        });
+    });
+});

--- a/src/statblock/registry.js
+++ b/src/statblock/registry.js
@@ -1,0 +1,86 @@
+/**
+ * Registry for system-specific statblock adapters.
+ * Adapters handle conversion between StatblockData and system-specific actor data.
+ *
+ * Each adapter must implement:
+ * - isSupported(): boolean - Check if system version is compatible
+ * - createActor(statblock, options): Promise<Actor> - Create actor from statblock
+ * - updateActor(existing, statblock): Promise<Actor> - Update existing actor
+ */
+class StatblockAdapterRegistry {
+    static _adapters = new Map();
+
+    /**
+     * Register an adapter for a specific game system.
+     *
+     * @param {string} systemId - The Foundry system ID (e.g., 'dnd5e')
+     * @param {object} adapter - The adapter instance
+     * @throws {Error} If adapter is missing required methods
+     */
+    static register(systemId, adapter) {
+        if (!systemId || typeof systemId !== 'string') {
+            throw new Error('StatblockAdapterRegistry.register requires a valid systemId string');
+        }
+
+        if (!adapter) {
+            throw new Error('StatblockAdapterRegistry.register requires an adapter');
+        }
+
+        const requiredMethods = ['isSupported', 'createActor', 'updateActor'];
+        for (const method of requiredMethods) {
+            if (typeof adapter[method] !== 'function') {
+                throw new Error(`Adapter for "${systemId}" is missing required method: ${method}`);
+            }
+        }
+
+        this._adapters.set(systemId, adapter);
+    }
+
+    /**
+     * Get the adapter for the current game system.
+     * Returns null if no adapter registered or if adapter reports unsupported.
+     *
+     * @returns {object|null} The adapter for game.system.id, or null if not available
+     */
+    static getAdapter() {
+        if (typeof game === 'undefined' || !game.system?.id) {
+            return null;
+        }
+
+        const adapter = this._adapters.get(game.system.id);
+        if (!adapter || !adapter.isSupported()) {
+            return null;
+        }
+
+        return adapter;
+    }
+
+    /**
+     * Check if statblock import is available for the current system.
+     *
+     * @returns {boolean} True if an adapter is registered for the current system
+     */
+    static isAvailable() {
+        return this.getAdapter() !== null;
+    }
+
+    /**
+     * Get all registered system IDs.
+     * Primarily useful for debugging and testing.
+     *
+     * @returns {string[]} Array of registered system IDs
+     */
+    static getRegisteredSystems() {
+        return Array.from(this._adapters.keys());
+    }
+
+    /**
+     * Clear all registered adapters.
+     * Primarily useful for testing.
+     */
+    static clear() {
+        this._adapters.clear();
+    }
+}
+
+export default StatblockAdapterRegistry;

--- a/src/statblock/registry.test.js
+++ b/src/statblock/registry.test.js
@@ -1,0 +1,166 @@
+import StatblockAdapterRegistry from './registry';
+
+describe('StatblockAdapterRegistry', () => {
+    beforeEach(() => {
+        StatblockAdapterRegistry.clear();
+        delete globalThis.game;
+    });
+
+    afterEach(() => {
+        StatblockAdapterRegistry.clear();
+        delete globalThis.game;
+    });
+
+    function createValidAdapter(overrides = {}) {
+        return {
+            isSupported: () => true,
+            createActor: async () => ({}),
+            updateActor: async () => ({}),
+            ...overrides
+        };
+    }
+
+    describe('register()', () => {
+        it('should store adapter', () => {
+            const adapter = createValidAdapter();
+            StatblockAdapterRegistry.register('dnd5e', adapter);
+
+            expect(StatblockAdapterRegistry.getRegisteredSystems()).toContain('dnd5e');
+        });
+
+        it('should throw if systemId is not a string', () => {
+            const adapter = createValidAdapter();
+
+            expect(() => StatblockAdapterRegistry.register(null, adapter))
+                .toThrow('requires a valid systemId string');
+            expect(() => StatblockAdapterRegistry.register(123, adapter))
+                .toThrow('requires a valid systemId string');
+            expect(() => StatblockAdapterRegistry.register('', adapter))
+                .toThrow('requires a valid systemId string');
+        });
+
+        it('should throw if adapter is missing', () => {
+            expect(() => StatblockAdapterRegistry.register('dnd5e', null))
+                .toThrow('requires an adapter');
+            expect(() => StatblockAdapterRegistry.register('dnd5e', undefined))
+                .toThrow('requires an adapter');
+        });
+
+        it('should throw if adapter is missing isSupported method', () => {
+            const adapter = {
+                createActor: async () => ({}),
+                updateActor: async () => ({})
+            };
+
+            expect(() => StatblockAdapterRegistry.register('dnd5e', adapter))
+                .toThrow('missing required method: isSupported');
+        });
+
+        it('should throw if adapter is missing createActor method', () => {
+            const adapter = {
+                isSupported: () => true,
+                updateActor: async () => ({})
+            };
+
+            expect(() => StatblockAdapterRegistry.register('dnd5e', adapter))
+                .toThrow('missing required method: createActor');
+        });
+
+        it('should throw if adapter is missing updateActor method', () => {
+            const adapter = {
+                isSupported: () => true,
+                createActor: async () => ({})
+            };
+
+            expect(() => StatblockAdapterRegistry.register('dnd5e', adapter))
+                .toThrow('missing required method: updateActor');
+        });
+    });
+
+    describe('getAdapter()', () => {
+        it('should return null when game is undefined', () => {
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+
+            expect(StatblockAdapterRegistry.getAdapter()).toBeNull();
+        });
+
+        it('should return null when game.system is undefined', () => {
+            globalThis.game = {};
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+
+            expect(StatblockAdapterRegistry.getAdapter()).toBeNull();
+        });
+
+        it('should return null when no adapter for current system', () => {
+            globalThis.game = { system: { id: 'pf2e' } };
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+
+            expect(StatblockAdapterRegistry.getAdapter()).toBeNull();
+        });
+
+        it('should return null when adapter reports unsupported', () => {
+            globalThis.game = { system: { id: 'dnd5e' } };
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter({
+                isSupported: () => false
+            }));
+
+            expect(StatblockAdapterRegistry.getAdapter()).toBeNull();
+        });
+
+        it('should return adapter when registered and supported', () => {
+            globalThis.game = { system: { id: 'dnd5e' } };
+            const adapter = createValidAdapter();
+            StatblockAdapterRegistry.register('dnd5e', adapter);
+
+            expect(StatblockAdapterRegistry.getAdapter()).toBe(adapter);
+        });
+    });
+
+    describe('isAvailable()', () => {
+        it('should return false when no adapter available', () => {
+            globalThis.game = { system: { id: 'pf2e' } };
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+
+            expect(StatblockAdapterRegistry.isAvailable()).toBe(false);
+        });
+
+        it('should return true when adapter is available', () => {
+            globalThis.game = { system: { id: 'dnd5e' } };
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+
+            expect(StatblockAdapterRegistry.isAvailable()).toBe(true);
+        });
+    });
+
+    describe('clear()', () => {
+        it('should remove all adapters', () => {
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+            StatblockAdapterRegistry.register('pf2e', createValidAdapter());
+
+            expect(StatblockAdapterRegistry.getRegisteredSystems()).toHaveLength(2);
+
+            StatblockAdapterRegistry.clear();
+
+            expect(StatblockAdapterRegistry.getRegisteredSystems()).toHaveLength(0);
+        });
+    });
+
+    describe('getRegisteredSystems()', () => {
+        it('should return empty array when no adapters registered', () => {
+            expect(StatblockAdapterRegistry.getRegisteredSystems()).toEqual([]);
+        });
+
+        it('should list all registered system IDs', () => {
+            StatblockAdapterRegistry.register('dnd5e', createValidAdapter());
+            StatblockAdapterRegistry.register('pf2e', createValidAdapter());
+            StatblockAdapterRegistry.register('swade', createValidAdapter());
+
+            const systems = StatblockAdapterRegistry.getRegisteredSystems();
+
+            expect(systems).toContain('dnd5e');
+            expect(systems).toContain('pf2e');
+            expect(systems).toContain('swade');
+            expect(systems).toHaveLength(3);
+        });
+    });
+});

--- a/src/ui/ImportDialog.js
+++ b/src/ui/ImportDialog.js
@@ -8,6 +8,7 @@ import executePipeline from '../pipeline/executePipeline';
 import createImportPipeline from '../pipeline/importPipeline';
 import ProgressModal from './ProgressModal.js';
 import { loadDialogPreferences, saveDialogPreferences } from './preferences.js';
+import StatblockAdapterRegistry from '../statblock/registry.js';
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -24,7 +25,9 @@ export default class ImportDialog extends HandlebarsApplicationMixin(Application
             importAssets: savedPrefs.importAssets ?? false,
             strictLineBreaks: savedPrefs.strictLineBreaks ?? false,
             splitByHeadings,
-            splitHeadingLevel: savedPrefs.splitHeadingLevel ?? 1
+            splitHeadingLevel: savedPrefs.splitHeadingLevel ?? 1,
+            importStatblocks: savedPrefs.importStatblocks ?? false,
+            statblockFolder: savedPrefs.statblockFolder ? game.folders?.get(savedPrefs.statblockFolder) : null
         });
     }
 
@@ -70,8 +73,21 @@ export default class ImportDialog extends HandlebarsApplicationMixin(Application
             strictLineBreaks: this.importOptions.strictLineBreaks,
             splitByHeadings: this.importOptions.splitByHeadings,
             splitHeadingLevel: this.importOptions.splitHeadingLevel,
-            dataPath: this.importOptions.dataPath
+            dataPath: this.importOptions.dataPath,
+            showStatblockOption: StatblockAdapterRegistry.isAvailable(),
+            importStatblocks: this.importOptions.importStatblocks,
+            statblockFolder: this.importOptions.statblockFolder?.id ?? null,
+            actorFolders: this._getActorFolders()
         };
+    }
+
+    _getActorFolders() {
+        if (typeof game === 'undefined' || !game.folders) {
+            return [];
+        }
+        return game.folders
+            .filter(f => f.type === 'Actor')
+            .map(f => ({ id: f.id, name: f.name }));
     }
 
     _onRender(context, options) {
@@ -139,6 +155,22 @@ export default class ImportDialog extends HandlebarsApplicationMixin(Application
             splitHeadingLevelSelect.value = String(this.importOptions.splitHeadingLevel);
             splitHeadingLevelSelect.addEventListener('change', event => {
                 this.importOptions.splitHeadingLevel = parseInt(event.target.value, 10);
+            });
+        }
+
+        const importStatblocksCheckbox = this.element.querySelector('input[name="importStatblocks"]');
+        if (importStatblocksCheckbox) {
+            importStatblocksCheckbox.addEventListener('change', async event => {
+                this.importOptions.importStatblocks = event.target.checked;
+                await this.render();
+            });
+        }
+
+        const statblockFolderSelect = this.element.querySelector('select[name="statblockFolder"]');
+        if (statblockFolderSelect) {
+            statblockFolderSelect.addEventListener('change', event => {
+                const folderId = event.target.value;
+                this.importOptions.statblockFolder = folderId ? game.folders.get(folderId) : null;
             });
         }
 
@@ -265,6 +297,8 @@ export default class ImportDialog extends HandlebarsApplicationMixin(Application
         this.importOptions.splitByHeadings = data.splitByHeadings || false;
         this.importOptions.splitHeadingLevel = parseInt(data.splitHeadingLevel, 10) || 1;
         this.importOptions.dataPath = data.dataPath || '';
+        this.importOptions.importStatblocks = data.importStatblocks || false;
+        this.importOptions.statblockFolder = data.statblockFolder ? game.folders.get(data.statblockFolder) : null;
 
         if (!this.importOptions.isValid()) {
             ui.notifications.warn(game.i18n.localize(`${MODULE_ID}.import.vault-path-hint`));
@@ -278,7 +312,9 @@ export default class ImportDialog extends HandlebarsApplicationMixin(Application
             strictLineBreaks: this.importOptions.strictLineBreaks,
             splitByHeadings: this.importOptions.splitByHeadings,
             splitHeadingLevel: this.importOptions.splitHeadingLevel,
-            dataPath: this.importOptions.dataPath
+            dataPath: this.importOptions.dataPath,
+            importStatblocks: this.importOptions.importStatblocks,
+            statblockFolder: this.importOptions.statblockFolder?.id ?? null
         });
 
         const showdownConverter = new showdown.Converter();

--- a/templates/import-dialog.hbs
+++ b/templates/import-dialog.hbs
@@ -86,6 +86,30 @@
         <p class="hint">{{localize "obsidian-bridge.import.data-path-hint"}}</p>
     </div>
     {{/if}}
+
+    {{#if showStatblockOption}}
+    <div class="form-group statblock-options">
+        <label>
+            <input type="checkbox" name="importStatblocks" {{checked importStatblocks}} />
+            {{localize "obsidian-bridge.import.statblock-label"}}
+        </label>
+        <p class="hint">{{localize "obsidian-bridge.import.statblock-hint"}}</p>
+    </div>
+
+    {{#if importStatblocks}}
+    <div class="form-group statblock-folder">
+        <label for="obsidian-statblock-folder">{{localize "obsidian-bridge.import.statblock-folder-label"}}</label>
+        <div class="form-fields">
+            <select id="obsidian-statblock-folder" name="statblockFolder">
+                <option value="">{{localize "obsidian-bridge.import.statblock-folder-none"}}</option>
+                {{#each actorFolders}}
+                <option value="{{this.id}}" {{#if (eq this.id ../statblockFolder)}}selected{{/if}}>{{this.name}}</option>
+                {{/each}}
+            </select>
+        </div>
+    </div>
+    {{/if}}
+    {{/if}}
     {{/if}}
 
     <footer class="form-footer flexrow">


### PR DESCRIPTION
Add the ability to parse Fantasy Statblock code blocks from Obsidian markdown files and create fully-configured dnd5e NPC actors. When the dnd5e system is active, a new "Import Statblocks as Actors" checkbox appears in the import dialog.

## Changes

- **Core parsing infrastructure**: Extract `statblock` code blocks from markdown, parse YAML into intermediate `StatblockData` representation
- **dnd5e adapter**: Map statblock data to dnd5e v5.1+ NPC actor schema with full activity support
- **Attack activities**: Parse attack descriptions to extract attack bonus, damage, range/reach, and damage type
- **Save activities**: Extract saving throw DC and ability from action descriptions
- **Targeting**: Parse area effects (emanations, cones, spheres) and range specifications
- **Limited use abilities**: Support for Recharge 5-6, X/Day, X/Short Rest, X/Long Rest patterns
- **Reaction triggers**: Extract trigger text into activation conditions
- **Spellcasting**: Parse innate and prepared spellcasting, look up spells from compendiums
- **Equipment**: Parse gear traits and look up items from compendiums
- **Folder mirroring**: Create Actor folder structure matching the vault's folder hierarchy
- **Conflict handling**: Update existing actors on re-import, skip name conflicts with untracked actors
- **UI integration**: Checkbox and folder picker in import dialog (only visible when dnd5e is active)

## Related Issues

None

## Breaking Changes

None