### PR TITLE
fix: Allow exporting files with colons in the title

### DIFF
--- a/src/journal/prepare.js
+++ b/src/journal/prepare.js
@@ -80,12 +80,16 @@ function createPageFile(journal, page) {
     });
 }
 
+function sanitizeName(name) {
+    return name.replace(/:/g, '');
+}
+
 function buildFolderPath(folder) {
     const parts = [];
     let current = folder;
 
     while (current) {
-        parts.unshift(current.name);
+        parts.unshift(sanitizeName(current.name));
         current = current.folder;
     }
 
@@ -93,21 +97,23 @@ function buildFolderPath(folder) {
 }
 
 function buildFilePath(folder, journalName, pageName = null) {
+    const sanitizedJournalName = sanitizeName(journalName);
+    const sanitizedPageName = pageName ? sanitizeName(pageName) : null;
     const folderPath = buildFolderPath(folder);
-    const isCombinedFolder = folderPath && journalName === folderPath.split('/').pop();
+    const isCombinedFolder = folderPath && sanitizedJournalName === folderPath.split('/').pop();
 
-    if (pageName) {
+    if (sanitizedPageName) {
         if (isCombinedFolder) {
-            return `${folderPath}/${pageName}.md`;
+            return `${folderPath}/${sanitizedPageName}.md`;
         }
         if (folderPath) {
-            return `${folderPath}/${journalName}/${pageName}.md`;
+            return `${folderPath}/${sanitizedJournalName}/${sanitizedPageName}.md`;
         }
-        return `${journalName}/${pageName}.md`;
+        return `${sanitizedJournalName}/${sanitizedPageName}.md`;
     }
 
     if (folderPath) {
-        return `${folderPath}/${journalName}.md`;
+        return `${folderPath}/${sanitizedJournalName}.md`;
     }
-    return `${journalName}.md`;
+    return `${sanitizedJournalName}.md`;
 }

--- a/src/journal/prepare.test.js
+++ b/src/journal/prepare.test.js
@@ -644,6 +644,85 @@ describe('prepareJournalsForExport', () => {
         });
     });
 
+    describe('special characters in names', () => {
+        it('should sanitize colons in folder (package) names', () => {
+            const folder = createMockFolder('Act 1: The Reckoning');
+
+            const journals = [
+                {
+                    name: 'Chapter 1',
+                    uuid: 'JournalEntry.ch1',
+                    folder,
+                    pages: {
+                        contents: [
+                            {
+                                name: 'Opening',
+                                uuid: 'JournalEntry.ch1.JournalEntryPage.p1',
+                                text: { content: '<p>It begins.</p>' }
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            const result = prepareJournalsForExport(journals, { merge: false });
+
+            expect(result[0].filePath).not.toContain(':');
+        });
+
+        it('should sanitize colons in journal entry names', () => {
+            const journals = [
+                {
+                    name: 'Act 1: The Reckoning',
+                    uuid: 'JournalEntry.act1',
+                    folder: null,
+                    pages: {
+                        contents: [
+                            {
+                                name: 'Opening',
+                                uuid: 'JournalEntry.act1.JournalEntryPage.p1',
+                                text: { content: '<p>It begins.</p>' }
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            const result = prepareJournalsForExport(journals, { merge: false });
+
+            expect(result[0].filePath).not.toContain(':');
+        });
+
+        it('should sanitize colons in page names', () => {
+            const journals = [
+                {
+                    name: 'Campaign Notes',
+                    uuid: 'JournalEntry.notes',
+                    folder: null,
+                    pages: {
+                        contents: [
+                            {
+                                name: 'Session 1: Introduction',
+                                uuid: 'JournalEntry.notes.JournalEntryPage.p1',
+                                text: { content: '<p>First session.</p>' }
+                            },
+                            {
+                                name: 'Session 2: The Twist',
+                                uuid: 'JournalEntry.notes.JournalEntryPage.p2',
+                                text: { content: '<p>Second session.</p>' }
+                            }
+                        ]
+                    }
+                }
+            ];
+
+            const result = prepareJournalsForExport(journals, { merge: false });
+
+            expect(result[0].filePath).not.toContain(':');
+            expect(result[1].filePath).not.toContain(':');
+        });
+    });
+
     describe('edge cases', () => {
         it('should return empty array for null journals', () => {
             const result = prepareJournalsForExport(null);


### PR DESCRIPTION
Currently, `obsidian-bridge` failed to export files that have colons in the name. e.g. `Act 1: Introduction` 

This PR sanitizes file and folder names before trying to export them. 